### PR TITLE
LPS-77971 Fix bug with predefined values for multiple checkbox field

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-type-checkbox-multiple/src/main/java/com/liferay/dynamic/data/mapping/type/checkbox/multiple/internal/CheckboxMultipleDDMFormFieldValueRequestParameterRetriever.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-type-checkbox-multiple/src/main/java/com/liferay/dynamic/data/mapping/type/checkbox/multiple/internal/CheckboxMultipleDDMFormFieldValueRequestParameterRetriever.java
@@ -18,6 +18,7 @@ import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueRequest
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Objects;
@@ -61,8 +62,13 @@ public class CheckboxMultipleDDMFormFieldValueRequestParameterRetriever
 			return GetterUtil.DEFAULT_STRING_VALUES;
 		}
 
-		return jsonFactory.looseDeserialize(
-			defaultDDMFormFieldParameterValue, String[].class);
+		try {
+			return jsonFactory.looseDeserialize(
+				defaultDDMFormFieldParameterValue, String[].class);
+		}
+		catch (Exception e) {
+			return StringUtil.split(defaultDDMFormFieldParameterValue);
+		}
 	}
 
 	@Reference


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-77971

NOTE: This is mainly a fix for 7.0.x. However, there was no reason that I could find for the fix not to be included in master as well. The only reason the fix would have been excluded from master is if the upgrade process from 7.0 to 7.1 would override this fix, but as it seems to not do this, I am making this pull request. Once this is merged, it will be backported to 7.0.x.

Proposed fix: I placed the original return statement in a try-catch. If an exception is thrown, use StringUtil to format the predefinedValue. This way, folks who have been using predefined values in multiple checkboxes previously with quotations won't have to change it to not have quotes. At the same time, the fix will include the more intuitive method of setting predefined values for such input fields without quotations.