### PR TITLE
LPS-78495

### DIFF
--- a/modules/apps/foundation/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/EhcachePortalCacheManager.java
+++ b/modules/apps/foundation/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/EhcachePortalCacheManager.java
@@ -204,10 +204,6 @@ public class EhcachePortalCacheManager<K extends Serializable, V>
 	protected void initPortalCacheConfiguratorSettingsServiceTracker(
 		BundleContext bundleContext) {
 
-		if (_cacheManager != null) {
-			return;
-		}
-
 		String filterString = StringBundler.concat(
 			"(&(objectClass=", PortalCacheConfiguratorSettings.class.getName(),
 			")(", PortalCacheManager.PORTAL_CACHE_MANAGER_NAME, "=",

--- a/modules/apps/foundation/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/MultiVMEhcachePortalCacheManager.java
+++ b/modules/apps/foundation/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/MultiVMEhcachePortalCacheManager.java
@@ -29,8 +29,6 @@ import com.liferay.portal.kernel.util.PropsKeys;
 
 import java.io.Serializable;
 
-import java.util.Map;
-
 import javax.management.MBeanServer;
 
 import org.osgi.framework.BundleContext;
@@ -54,9 +52,7 @@ public class MultiVMEhcachePortalCacheManager
 		extends EhcachePortalCacheManager<K, V> {
 
 	@Activate
-	protected void activate(
-		BundleContext bundleContext, Map<String, Object> properties) {
-
+	protected void activate(BundleContext bundleContext) {
 		setClusterAware(true);
 		setConfigFile(props.get(PropsKeys.EHCACHE_MULTI_VM_CONFIG_LOCATION));
 		setDefaultConfigFile(_DEFAULT_CONFIG_FILE_NAME);

--- a/modules/apps/foundation/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/MultiVMEhcachePortalCacheManager.java
+++ b/modules/apps/foundation/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/MultiVMEhcachePortalCacheManager.java
@@ -37,7 +37,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -55,7 +54,6 @@ public class MultiVMEhcachePortalCacheManager
 		extends EhcachePortalCacheManager<K, V> {
 
 	@Activate
-	@Modified
 	protected void activate(
 		BundleContext bundleContext, Map<String, Object> properties) {
 

--- a/modules/apps/foundation/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/SingleVMEhcachePortalCacheManager.java
+++ b/modules/apps/foundation/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/SingleVMEhcachePortalCacheManager.java
@@ -26,8 +26,6 @@ import com.liferay.portal.kernel.util.PropsKeys;
 
 import java.io.Serializable;
 
-import java.util.Map;
-
 import javax.management.MBeanServer;
 
 import org.osgi.framework.BundleContext;
@@ -50,9 +48,7 @@ public class SingleVMEhcachePortalCacheManager<K extends Serializable, V>
 	extends EhcachePortalCacheManager<K, V> {
 
 	@Activate
-	protected void activate(
-		BundleContext bundleContext, Map<String, Object> properties) {
-
+	protected void activate(BundleContext bundleContext) {
 		setConfigFile(props.get(PropsKeys.EHCACHE_SINGLE_VM_CONFIG_LOCATION));
 		setDefaultConfigFile(_DEFAULT_CONFIG_FILE_NAME);
 		setPortalCacheManagerName(PortalCacheManagerNames.SINGLE_VM);

--- a/modules/apps/foundation/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/SingleVMEhcachePortalCacheManager.java
+++ b/modules/apps/foundation/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/SingleVMEhcachePortalCacheManager.java
@@ -34,7 +34,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -51,7 +50,6 @@ public class SingleVMEhcachePortalCacheManager<K extends Serializable, V>
 	extends EhcachePortalCacheManager<K, V> {
 
 	@Activate
-	@Modified
 	protected void activate(
 		BundleContext bundleContext, Map<String, Object> properties) {
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-78495

After consulting with Preston and Minhchau about this ticket, they acknowledged that including the if check that I am removing was placed as an honest mistake. It breaks the test-cache-configuration-portlet which can be generated from the liferay-plugins-ee repository. I consulted with these two, because they helped to author commits related to the pull request that introduced this if check.

After removing the if check, the tests for the test-cache-configuration-portlet passes without breaking any other functionality, to the best of my knowledge.