### PR TITLE
LPS-78244

### DIFF
--- a/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -578,6 +578,13 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		MBMessage message = mbMessagePersistence.findByPrimaryKey(messageId);
 
+		List<MBMessage> childrenMessages = mbMessagePersistence.findByT_P(
+			message.getThreadId(), message.getMessageId());
+
+		for (MBMessage childMessage : childrenMessages) {
+			deleteDiscussionMessage(childMessage.getMessageId());
+		}
+
 		SocialActivityManagerUtil.deleteActivities(message);
 
 		return mbMessageLocalService.deleteMessage(messageId);


### PR DESCRIPTION
JIRA: https://issues.liferay.com/browse/LPS-78244

Problem: Child comments do not delete when a parent comment is deleted in a message thread. The expected behavior is that all child comments should be deleted in addition to the parent comment being deleted.

Solution: Altered the deletion `deleteDiscussionMessage(long messageId)` method of `MBMessageLocalServiceImpl.java` to recursively check for child comments and delete them as well.