### PR TITLE
LPS-78055 On display unarchived request notifications in search container.

### DIFF
--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
@@ -58,7 +58,14 @@ if (notificationUnread) {
 	<c:otherwise>
 		<portlet:actionURL name="markNotificationAsRead" var="markNotificationAsReadURL">
 			<portlet:param name="userNotificationEventId" value="<%= String.valueOf(userNotificationEvent.getUserNotificationEventId()) %>" />
-			<portlet:param name="redirect" value="<%= userNotificationFeedEntry.getLink() %>" />
+			<c:choose>
+				<c:when test="<%= userNotificationFeedEntry.getLink() == StringPool.BLANK %>">
+					<portlet:param name="redirect" value="<%= currentURL %>" />
+				</c:when>
+				<c:otherwise>
+					<portlet:param name="redirect" value="<%= userNotificationFeedEntry.getLink() %>" />
+				</c:otherwise>
+			</c:choose>
 		</portlet:actionURL>
 
 		<liferay-ui:search-container-column-text colspan="<%= 2 %>">

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -30,6 +30,7 @@ String searchContainerId = "userNotificationEvents";
 
 if (actionRequired) {
 	searchContainerId = "actionableUserNotificationEvents";
+	navigation = "unread";
 }
 
 notificationsSearchContainer.setId(searchContainerId);
@@ -59,7 +60,7 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 
 		<aui:nav-item
 			href="<%= viewRequestsURL %>"
-			label='<%= LanguageUtil.format(request, "requests-list-x", String.valueOf(UserNotificationEventLocalServiceUtil.getDeliveredUserNotificationEventsCount(themeDisplay.getUserId(), UserNotificationDeliveryConstants.TYPE_WEBSITE, true, true))) %>'
+			label='<%= LanguageUtil.format(request, "requests-list-x", String.valueOf(UserNotificationEventLocalServiceUtil.getArchivedUserNotificationEventsCount(themeDisplay.getUserId(), UserNotificationDeliveryConstants.TYPE_WEBSITE, true, false))) %>'
 			selected="<%= actionRequired %>"
 		/>
 	</aui:nav>
@@ -185,6 +186,7 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 									A.io.request(markAsReadURL);
 
 									notificationContainer.remove();
+									location.reload(true);
 								}
 							}
 							else {

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -182,11 +182,10 @@ navigationURL.setParameter(SearchContainer.DEFAULT_CUR_PARAM, "0");
 
 								if (notificationContainer) {
 									var markAsReadURL = notificationContainer.one('a').attr('href');
-
-									A.io.request(markAsReadURL);
-
 									notificationContainer.remove();
-									location.reload(true);
+
+									form.attr('method', 'post');
+									submitForm(form, markAsReadURL);
 								}
 							}
 							else {


### PR DESCRIPTION
Ticket: [LPS-78055](https://issues.liferay.com/browse/LPS-78055)

Problem: After a user Confirms/ignores a request notification the notification does not disappear from the search container. Instead the notification's body is replaced with the message "Notification no longer applies, notification for invite members was deleted".

Solution: The cause of the problem was the search containers results were being populated with all of the notifications that were designated as 'actionRequired'. This filter was too broad because this includes request notifications that the user already clicked on/archived. The solution was to make sure the search container results were populated with notifications that have 'actionRequired==true' and 'archived==false'. Archived set to false means the notification has not yet been read.

It is also necessary to force a page refresh to get the updated search container to display correctly. In a previous PR I refreshed the page using location.reload() in notification/view.jsp. This was a bad approach because the action was being processed after the page reloaded instead of before. To ensure the page is refreshed after the action is processed I instead submitted the form and set the method to 'post'. 