### PR TITLE
LPS-79311 Log if two bundles have the same Web-ContextPath

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WebBundleDeployer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WebBundleDeployer.java
@@ -68,7 +68,7 @@ public class WebBundleDeployer {
 	}
 
 	public ServiceRegistration<PortalProfile> doStart(Bundle bundle) {
-		_eventUtil.sendEvent(bundle, EventUtil.DEPLOYING, null, false);
+		_eventUtil.sendEvent(bundle, EventUtil.DEPLOYING, null, true);
 
 		String contextPath = WabUtil.getWebContextPath(bundle);
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/event/EventUtil.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/event/EventUtil.java
@@ -15,6 +15,8 @@
 package com.liferay.portal.osgi.web.wab.extender.internal.event;
 
 import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.osgi.web.wab.extender.internal.WabUtil;
@@ -99,9 +101,9 @@ public class EventUtil
 			WabUtil.getWebContextPath(bundle));
 
 		if (collision) {
-			properties.put("collision", contextPath);
-
 			List<Long> collidedBundleIds = new ArrayList<>();
+
+			String collidedBundleNames = bundle.toString();
 
 			BundleContext bundleContext = bundle.getBundleContext();
 
@@ -118,10 +120,20 @@ public class EventUtil
 					curContextPath.equals(contextPath)) {
 
 					collidedBundleIds.add(curBundle.getBundleId());
+					collidedBundleNames += "," + curBundle.toString();
 				}
 			}
 
-			properties.put("collision.bundles", collidedBundleIds);
+			if (!collidedBundleIds.isEmpty()) {
+				properties.put("collision", contextPath);
+
+				properties.put("collision.bundles", collidedBundleIds);
+
+				_log.warn("Bundles " + collidedBundleNames +
+				" have the same Web-ContextPath. This can lead to" +
+				" unexpected behavior when the bundles are deployed" +
+				" to the same layout");
+			}
 		}
 
 		properties.put("context.path", contextPath);
@@ -154,6 +166,8 @@ public class EventUtil
 
 		_eventAdmin.sendEvent(event);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(EventUtil.class);
 
 	private final BundleContext _bundleContext;
 	private EventAdmin _eventAdmin;


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-79311
LPP: https://issues.liferay.com/browse/LPP-29419

Problem: When two bundles have the same `Web-ContextPath` no log message is displayed to illustrate the potential problem having two Web-ContextPath set to the same value can have. Having the Web-ContextPath set to the same value can cause unexpected behavior for the portlets with the same Web-ContextPath. Without an error or warning message it can be difficult for the user to identify the root cause of the issue.

Solution: There already exists a collision check in `EventUtil.java` that can identify when multiple bundles have the same Web-ContextPath. I made slight modifications to the collision check and added a log statement at the end of the collision check. The collision check is triggered when a portlet is first deployed. The log will give user a warning and list out all bundles that have collisions if a collision is detected.  