### PR TITLE
LPS-84351 Removed infinite loop from onDataReady

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
@@ -319,9 +319,10 @@ AUI.add(
 						var instance = this;
 
 						if (instance._pendingData) {
-							instance.getNativeEditor().setData(instance._pendingData);
+							var pendingData = instance._pendingData;
 
 							instance._pendingData = null;
+							instance.getNativeEditor().setData(pendingData);
 						}
 						else {
 							instance._dataReady = true;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -591,9 +591,10 @@ name = HtmlUtil.escapeJS(name);
 			'dataReady',
 			function(event) {
 				if (instancePendingData) {
-					ckEditor.setData(instancePendingData);
+					var pendingData = instancePendingData);
 
 					instancePendingData = null;
+					ckEditor.setData(pendingData);
 				}
 				else {
 					instanceDataReady = true;


### PR DESCRIPTION
Issue: @ [LPS-84351](https://issues.liferay.com/browse/LPS-84351)
Previous PR: [685](https://github.com/MichaelPrigge/liferay-portal-ee/pull/685)

This commit fixes an infinite loop within `_onDataReady`, which is fired again before the flag can be reset. The infinite loop is never accessed in master and 7.1.x, but produces a bug in 7.0.x, referenced in [LPS-84351](https://issues.liferay.com/browse/LPS-84351). The fix for the bug will be backported from this change in master. While it does not affect functionality in master or 7.1.x, fixing this function will prevent issues from this function from arising in the future. 