### PR TITLE
LPS-85960 Added flag to bypass URL modification for absolute URLs

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -213,6 +213,7 @@ public class LayoutReferencesExportImportContentProcessor
 		StringBuilder sb = new StringBuilder(content);
 
 		String[] patterns = {"href=", "[["};
+		boolean relativeURLFlag = false;
 
 		int beginPos = -1;
 		int endPos = content.length();
@@ -263,10 +264,15 @@ public class LayoutReferencesExportImportContentProcessor
 				url = url.substring(0, url.length() - 1);
 			}
 
+			String cleanURL = url;
 			StringBundler urlSB = new StringBundler(6);
 
 			try {
 				url = replaceExportHostname(group, url, urlSB);
+
+				if (url != cleanURL) {
+					relativeURLFlag = true;
+				}
 
 				if (!url.startsWith(StringPool.SLASH)) {
 					continue;
@@ -302,6 +308,8 @@ public class LayoutReferencesExportImportContentProcessor
 				}
 
 				if (locale != null) {
+					relativeURLFlag = true;
+
 					String urlWithoutLocale = url.substring(
 						localePath.length());
 
@@ -522,6 +530,10 @@ public class LayoutReferencesExportImportContentProcessor
 					urlSB.append(url);
 
 					url = urlSB.toString();
+				}
+
+				if (!relativeURLFlag) {
+					url = cleanURL;
 				}
 
 				sb.replace(beginPos + offset, endPos, url);


### PR DESCRIPTION
@ [LPS-85960](https://issues.liferay.com/browse/LPS-85960)
Issue: When staging, Liferay parses URLs in content to check for relative URLs within different environments and modifies them as needed to preserve links. It does this for both relative and absolute URLs. In this case, an absolute URL does not follow Liferay's URL formats and is modified, thus breaking the link upon staging.

Solution: I added a flag that tests to see whether the URL is an absolute or relative URL. If it is determined that a URL is absolute, it will not make any changes to the address, thus preserving the link.