### PR TITLE
LPS-85718

### DIFF
--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/resources/META-INF/resources/view.jsp
@@ -78,7 +78,7 @@ ruleGroupSearch.setResults(mdrRuleGroups);
 
 		<c:if test="<%= MDRPermission.contains(permissionChecker, groupId, ActionKeys.ADD_RULE_GROUP) %>">
 			<portlet:renderURL var="viewRulesURL">
-				<portlet:param name="mvcRenderCommandName" value="/view.jsp" />
+				<portlet:param name="mvcRenderCommandName" value="/mobile_device_rules/view" />
 				<portlet:param name="groupId" value="<%= String.valueOf(groupId) %>" />
 				<portlet:param name="className" value="<%= className %>" />
 				<portlet:param name="classPK" value="<%= String.valueOf(classPK) %>" />


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-85718

Problem:  A warning is thrown when a new Mobile Device Family is saved.  This error is thrown because the `value` referenced for the portlet parameter `mvcRenderCommandName` in the JSP does not match the MVC command name defined in [ViewMVCRenderCommand.java](https://github.com/liferay/liferay-portal/blob/65059440dfaf2b8b365a20f99e83e4cdb15478aa/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/portlet/action/ViewMVCRenderCommand.java).

Solution:  Change the `value` of the portlet parameter to match the MVC command name defined in [ViewMVCRenderCommand.java](https://github.com/liferay/liferay-portal/blob/65059440dfaf2b8b365a20f99e83e4cdb15478aa/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/portlet/action/ViewMVCRenderCommand.java).