### PR TITLE
LPS-86161 Obscure sensitive User information in StaleObject logging

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
@@ -16,6 +16,8 @@ package com.liferay.portal.dao.orm.hibernate;
 
 import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.ObjectNotFoundException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 
 import com.liferay.portal.kernel.model.User;
@@ -40,7 +42,7 @@ public class ExceptionTranslator {
 	public static ORMException translate(
 		Exception e, Session session, Object object) {
 
-		if (e instanceof StaleObjectStateException) {
+		if (e instanceof StaleObjectStateException && _log.isDebugEnabled()) {
 			BaseModel<?> baseModel = (BaseModel<?>)object;
 
 			Object currentObject = session.get(
@@ -85,4 +87,5 @@ public class ExceptionTranslator {
 			tempUser + " is stale in comparison to " + tempCurrUser, e);
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(ExceptionTranslator.class);
 }

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
@@ -18,6 +18,8 @@ import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.ObjectNotFoundException;
 import com.liferay.portal.kernel.model.BaseModel;
 
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.model.impl.UserImpl;
 import org.hibernate.Session;
 import org.hibernate.StaleObjectStateException;
 
@@ -44,12 +46,43 @@ public class ExceptionTranslator {
 			Object currentObject = session.get(
 				object.getClass(), baseModel.getPrimaryKeyObj());
 
+			if (object instanceof UserImpl) {
+				translateUserSOSE(object, currentObject, e);
+			}
+
 			return new ORMException(
 				object + " is stale in comparison to " + currentObject, e);
 		}
 		else {
 			return new ORMException(e);
 		}
+	}
+
+	private static ORMException translateUserSOSE(
+		Object object, Object currentObject, Exception e) {
+
+		User tempUser = (User) object;
+		User tempCurrUser = (User) currentObject;
+
+		for (User user: new User[]{tempUser, tempCurrUser}) {
+
+			user.setDigest("");
+			user.setEmailAddress("");
+			user.setFacebookId(-1);
+			user.setFirstName("");
+			user.setGoogleUserId("");
+			user.setGreeting("");
+			user.setJobTitle("");
+			user.setLastName("");
+			user.setMiddleName("");
+			user.setPassword("");
+			user.setScreenName("");
+			user.setReminderQueryAnswer("");
+			user.setReminderQueryQuestion("");
+		}
+
+		return new ORMException(
+			tempUser + " is stale in comparison to " + tempCurrUser, e);
 	}
 
 }


### PR DESCRIPTION
@[LPS-86161](https://issues.liferay.com/browse/LPS-86161)
Issue: When Liferay encounters database-related exceptions regarding the User model, the entire model is stored into the logs, including the hashed password and the plaintext security question answer, as well as personal information such as name, birthday, and email. According to OWASP (Open Web Application Security Project), it is [good practice](https://www.owasp.org/index.php/Logging_Cheat_Sheet) to not ever log sensitive information, is currently done in handling StaleObject exceptions.

Solution: In the case of a StaleObject exception, I added a check that the logging level must be set to Debug for the model to be recorded. Specifically for stale User objects, I also obscure fields that may contain personal information.