### PR TITLE
LPS-86181 Obscure sensitive User information in logs

### DIFF
--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -124,6 +124,10 @@
 		<priority value="ERROR" />
 	</category>
 
+	<category name="com.liferay.portal.dao.orm.hibernate.ExceptionTranslator">
+		<priority value="ERROR" />
+	</category>
+
 	<category name="com.liferay.portal.dao.orm.hibernate.SessionFactoryImpl">
 		<priority value="ERROR" />
 	</category>

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
- *
+ * <p>
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2.1 of the License, or (at your option)
  * any later version.
- *
+ * <p>
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
@@ -17,6 +17,8 @@ package com.liferay.portal.dao.orm.hibernate;
 import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.ObjectNotFoundException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.model.impl.UserImpl;
 
 import org.hibernate.Session;
 import org.hibernate.StaleObjectStateException;
@@ -44,12 +46,52 @@ public class ExceptionTranslator {
 			Object currentObject = session.get(
 				object.getClass(), baseModel.getPrimaryKeyObj());
 
+			if (object instanceof UserImpl) {
+				translateUserSOSE(object, currentObject, e);
+			}
+
 			return new ORMException(
 				object + " is stale in comparison to " + currentObject, e);
 		}
 		else {
 			return new ORMException(e);
 		}
+	}
+
+	private static String hideField(String currField) {
+		if (currField != null && currField != "") {
+			return "****";
+		}
+
+		return "";
+	}
+
+	private static ORMException translateUserSOSE(
+		Object object, Object currentObject, Exception e) {
+
+		User tempUser = (User)object;
+		User tempCurrUser = (User)currentObject;
+
+		for (User user : new User[] {tempUser, tempCurrUser}) {
+			user.setPassword(hideField(user.getPassword()));
+			user.setDigest(hideField(user.getDigest()));
+			user.setReminderQueryQuestion(
+				hideField(user.getReminderQueryQuestion()));
+			user.setReminderQueryAnswer(
+				hideField(user.getReminderQueryAnswer()));
+			user.setScreenName(hideField(user.getScreenName()));
+			user.setEmailAddress(hideField(user.getEmailAddress()));
+			user.setFacebookId((user.getFacebookId() != 0) ? 0 : -1);
+			user.setGoogleUserId(hideField(user.getGoogleUserId()));
+			user.setGreeting(hideField(user.getGreeting()));
+			user.setFirstName(hideField(user.getFirstName()));
+			user.setMiddleName(hideField(user.getMiddleName()));
+			user.setLastName(hideField(user.getLastName()));
+			user.setJobTitle(hideField(user.getJobTitle()));
+		}
+
+		return new ORMException(
+			tempUser + " is stale in comparison to " + tempCurrUser, e);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
@@ -16,6 +16,8 @@ package com.liferay.portal.dao.orm.hibernate;
 
 import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.ObjectNotFoundException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.model.impl.UserImpl;
@@ -40,7 +42,7 @@ public class ExceptionTranslator {
 	public static ORMException translate(
 		Exception e, Session session, Object object) {
 
-		if (e instanceof StaleObjectStateException) {
+		if (e instanceof StaleObjectStateException && _log.isDebugEnabled()) {
 			BaseModel<?> baseModel = (BaseModel<?>)object;
 
 			Object currentObject = session.get(
@@ -94,4 +96,5 @@ public class ExceptionTranslator {
 			tempUser + " is stale in comparison to " + tempCurrUser, e);
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(ExceptionTranslator.class);
 }


### PR DESCRIPTION
@[LPS-86161](https://issues.liferay.com/browse/LPS-86161) [#34](https://github.com/joshuacords/liferay-portal/pull/34)
Issue: When Liferay encounters database-related exceptions regarding the User model, the entire model is stored into the logs, including the hashed password and the plaintext security question answer, as well as personal information such as name, birthday, and email. According to OWASP (Open Web Application Security Project), it is [good practice](https://www.owasp.org/index.php/Logging_Cheat_Sheet) to not ever log sensitive information, as is currently done in handling StaleObject exceptions.

Solution: In the case of a StaleObject exception, I added a check that the logging level must be set to Debug for the model to be recorded. Specifically for stale User objects, I also obscure fields that may contain personal information. 