### PR TITLE
LPS-85960 Added Integration test to check that path of absolute URLs are not modified

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -261,6 +261,7 @@ public class LayoutReferencesExportImportContentProcessor
 
 			if (url.endsWith(StringPool.SLASH)) {
 				url = url.substring(0, url.length() - 1);
+				endPos--;
 			}
 
 			StringBundler urlSB = new StringBundler(6);

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -525,6 +525,25 @@ public class DefaultExportImportContentProcessorTest {
 	}
 
 	@Test
+	public void testExportLinksToURLSWithStopCharacters() throws Exception {
+		String path = RandomTestUtil.randomString();
+
+		String content = getContent("url_links.txt").replaceAll("PATH", path);
+
+		content = replaceLinksToLayoutsParameters(
+			content, _stagingPrivateLayout,
+			_stagingPublicLayout);
+
+		content = _exportImportContentProcessor.replaceExportContentReferences(
+			_portletDataContextExport, _referrerStagedModel, content, true,
+			true);
+
+		for (char stopChar: _LAYOUT_REFERENCE_STOP_CHARS) {
+			assertLinksToURLWithStopCharacters(content, path, stopChar);
+		}
+	}
+
+	@Test
 	public void testExportLinksToUserLayouts() throws Exception {
 		User user = TestPropsValues.getUser();
 
@@ -838,6 +857,19 @@ public class DefaultExportImportContentProcessorTest {
 		}
 
 		sb.append(StringPool.CLOSE_BRACKET);
+
+		Assert.assertTrue(content, content.contains(sb.toString()));
+	}
+
+	protected void assertLinksToURLWithStopCharacters(
+		String content, String path, char stopChar) {
+
+		StringBundler sb = new StringBundler();
+
+		sb.append(path);
+		sb.append(StringPool.SLASH);
+		sb.append(stopChar);
+		sb.append(StringPool.SLASH);
 
 		Assert.assertTrue(content, content.contains(sb.toString()));
 	}
@@ -1181,6 +1213,13 @@ public class DefaultExportImportContentProcessorTest {
 	private static final String[] _GROUP_FRIENDLY_URL_VARIABLES = {
 		"[$GROUP_FRIENDLY_URL$]", "[$PRIVATE_LAYOUT_FRIENDLY_URL$]",
 		"[$PUBLIC_LAYOUT_FRIENDLY_URL$]"
+	};
+
+	private static final char[] _LAYOUT_REFERENCE_STOP_CHARS = {
+		CharPool.APOSTROPHE, CharPool.CLOSE_BRACKET, CharPool.CLOSE_CURLY_BRACE,
+		CharPool.CLOSE_PARENTHESIS, CharPool.GREATER_THAN, CharPool.LESS_THAN,
+		CharPool.PIPE, CharPool.POUND, CharPool.QUESTION, CharPool.QUOTE,
+		CharPool.SPACE
 	};
 
 	private static final String[] _MULTI_LOCALE_LAYOUT_VARIABLES = {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/url_links.txt
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/url_links.txt
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<dynamic-element name="content" type="text_area" index-type="text" instance-id="qnll">
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/'/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/]/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/}/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/)/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/>/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/</" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/|/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/#/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/?/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/"/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/ /" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
@[LPS-85960](https://issues.liferay.com/browse/LPS-85960)

This integration test checks specifically that stop characters inserted into the path of a URL in staged web content does not alter the URL, which was the issue in [LPS-85960](https://issues.liferay.com/browse/LPS-85960). 

See previous conversation regarding this integration test here: https://github.com/moltam89/liferay-portal/pull/437