### PR TITLE
LPS-86161 Obfuscate sensitive user information

### DIFF
--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -124,6 +124,10 @@
 		<priority value="ERROR" />
 	</category>
 
+	<category name="com.liferay.portal.dao.orm.hibernate.ExceptionTranslator">
+		<priority value="ERROR" />
+	</category>
+
 	<category name="com.liferay.portal.dao.orm.hibernate.SessionFactoryImpl">
 		<priority value="ERROR" />
 	</category>

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
@@ -17,6 +17,8 @@ package com.liferay.portal.dao.orm.hibernate;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.ObjectNotFoundException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.model.impl.UserImpl;
@@ -47,7 +49,7 @@ public class ExceptionTranslator {
 			Object currentObject = session.get(
 				object.getClass(), baseModel.getPrimaryKeyObj());
 
-			if (object instanceof UserImpl) {
+			if (object instanceof UserImpl && _log.isDebugEnabled()) {
 				object = _obfuscate(object);
 				currentObject = _obfuscate(currentObject);
 			}
@@ -81,4 +83,5 @@ public class ExceptionTranslator {
 		return user;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(ExceptionTranslator.class);
 }

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/ExceptionTranslator.java
@@ -14,9 +14,12 @@
 
 package com.liferay.portal.dao.orm.hibernate;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.ObjectNotFoundException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.model.impl.UserImpl;
 
 import org.hibernate.Session;
 import org.hibernate.StaleObjectStateException;
@@ -44,12 +47,38 @@ public class ExceptionTranslator {
 			Object currentObject = session.get(
 				object.getClass(), baseModel.getPrimaryKeyObj());
 
+			if (object instanceof UserImpl) {
+				object = _obfuscate(object);
+				currentObject = _obfuscate(currentObject);
+			}
+
 			return new ORMException(
 				object + " is stale in comparison to " + currentObject, e);
 		}
 		else {
 			return new ORMException(e);
 		}
+	}
+
+	private static User _obfuscate(Object object) {
+
+		User user = (User)object;
+
+		user.setPassword(StringPool.EIGHT_STARS);
+		user.setDigest(StringPool.EIGHT_STARS);
+		user.setReminderQueryQuestion(StringPool.EIGHT_STARS);
+		user.setReminderQueryAnswer(StringPool.EIGHT_STARS);
+		user.setScreenName(StringPool.EIGHT_STARS);
+		user.setEmailAddress(StringPool.EIGHT_STARS);
+		user.setFacebookId((user.getFacebookId() != 0) ? 0 : -1);
+		user.setGoogleUserId(StringPool.EIGHT_STARS);
+		user.setGreeting(StringPool.EIGHT_STARS);
+		user.setFirstName(StringPool.EIGHT_STARS);
+		user.setMiddleName(StringPool.EIGHT_STARS);
+		user.setLastName(StringPool.EIGHT_STARS);
+		user.setJobTitle(StringPool.EIGHT_STARS);
+
+		return user;
 	}
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86161
https://issues.liferay.com/browse/LPP-31681

Implemented code-related comments from previous PR: https://github.com/SamZiemer/liferay-portal/pull/512#issuecomment-431067330

> Issue: When Liferay encounters database-related exceptions regarding the User model, the entire model is stored into the logs, including the hashed password and the plaintext security question answer, as well as personal information such as name, birthday, and email. According to OWASP (Open Web Application Security Project), it is [good practice](https://www.owasp.org/index.php/Logging_Cheat_Sheet) to not ever log sensitive information, as is currently done in handling StaleObject exceptions.
> 
> Solution: In the case of a StaleObject exception, I added a check that the logging level must be set to Debug for the model to be recorded. Specifically for stale User objects, I also obscure fields that may contain personal information.