### PR TITLE
LPS-89560 Added Integration test to check that path of absolute URLs are not modified

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -261,6 +261,7 @@ public class LayoutReferencesExportImportContentProcessor
 
 			if (url.endsWith(StringPool.SLASH)) {
 				url = url.substring(0, url.length() - 1);
+				endPos--;
 			}
 
 			StringBundler urlSB = new StringBundler(6);

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -525,6 +525,20 @@ public class DefaultExportImportContentProcessorTest {
 	}
 
 	@Test
+	public void testExportLinksToURLSWithStopCharacters() throws Exception {
+		String path = RandomTestUtil.randomString();
+
+		String content = getContent("url_links.txt");
+		content = content.replaceAll("PATH", path);
+
+		content = _exportImportContentProcessor.replaceExportContentReferences(
+			_portletDataContextExport, _referrerStagedModel, content, true,
+			true);
+
+		_assertContainsPathWithStopCharacters(content, path);
+	}
+
+	@Test
 	public void testExportLinksToUserLayouts() throws Exception {
 		User user = TestPropsValues.getUser();
 
@@ -1172,6 +1186,25 @@ public class DefaultExportImportContentProcessorTest {
 			entriesStream.anyMatch(entry -> entry.endsWith(expected)));
 	}
 
+	private void _assertContainsPathWithStopCharacters(
+		String content, String path) {
+
+		for (char stopChar: _LAYOUT_REFERENCE_STOP_CHARS) {
+			StringBundler sb = new StringBundler();
+
+			sb.append(path);
+			sb.append(StringPool.SLASH);
+			sb.append(stopChar);
+			sb.append(StringPool.SLASH);
+
+			Assert.assertTrue(
+				String.format(
+					"%s does not contain the path %s",
+					content, sb.toString()
+				), content.contains(sb.toString()));
+		}
+	}
+
 	private static final String[] _EXTERNAL_GROUP_FRIENDLY_URL_VARIABLES = {
 		"[$EXTERNAL_GROUP_FRIENDLY_URL$]",
 		"[$EXTERNAL_PRIVATE_LAYOUT_FRIENDLY_URL$]",
@@ -1181,6 +1214,13 @@ public class DefaultExportImportContentProcessorTest {
 	private static final String[] _GROUP_FRIENDLY_URL_VARIABLES = {
 		"[$GROUP_FRIENDLY_URL$]", "[$PRIVATE_LAYOUT_FRIENDLY_URL$]",
 		"[$PUBLIC_LAYOUT_FRIENDLY_URL$]"
+	};
+
+	private static final char[] _LAYOUT_REFERENCE_STOP_CHARS = {
+		CharPool.APOSTROPHE, CharPool.CLOSE_BRACKET, CharPool.CLOSE_CURLY_BRACE,
+		CharPool.CLOSE_PARENTHESIS, CharPool.GREATER_THAN, CharPool.LESS_THAN,
+		CharPool.PIPE, CharPool.POUND, CharPool.QUESTION, CharPool.QUOTE,
+		CharPool.SPACE
 	};
 
 	private static final String[] _MULTI_LOCALE_LAYOUT_VARIABLES = {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -529,6 +529,7 @@ public class DefaultExportImportContentProcessorTest {
 		String path = RandomTestUtil.randomString();
 
 		String content = getContent("url_links.txt");
+
 		content = content.replaceAll("PATH", path);
 
 		content = _exportImportContentProcessor.replaceExportContentReferences(
@@ -1172,6 +1173,24 @@ public class DefaultExportImportContentProcessorTest {
 			entriesStream.anyMatch(pattern.asPredicate()));
 	}
 
+	private void _assertContainsPathWithStopCharacters(
+		String content, String path) {
+
+		for (char stopChar : _LAYOUT_REFERENCE_STOP_CHARS) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(path);
+			sb.append(StringPool.SLASH);
+			sb.append(stopChar);
+			sb.append(StringPool.SLASH);
+
+			Assert.assertTrue(
+				String.format(
+					"%s does not contain the path %s", content,
+					sb.toString()), content.contains(sb.toString()));
+		}
+	}
+
 	private void _assertContainsReference(
 		List<String> entries, String className, long classPK) {
 
@@ -1184,25 +1203,6 @@ public class DefaultExportImportContentProcessorTest {
 				"%s does not contain an entry for %s with primary key %s",
 				entries.toString(), className, classPK),
 			entriesStream.anyMatch(entry -> entry.endsWith(expected)));
-	}
-
-	private void _assertContainsPathWithStopCharacters(
-		String content, String path) {
-
-		for (char stopChar: _LAYOUT_REFERENCE_STOP_CHARS) {
-			StringBundler sb = new StringBundler();
-
-			sb.append(path);
-			sb.append(StringPool.SLASH);
-			sb.append(stopChar);
-			sb.append(StringPool.SLASH);
-
-			Assert.assertTrue(
-				String.format(
-					"%s does not contain the path %s",
-					content, sb.toString()
-				), content.contains(sb.toString()));
-		}
 	}
 
 	private static final String[] _EXTERNAL_GROUP_FRIENDLY_URL_VARIABLES = {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/url_links.txt
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/url_links.txt
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<dynamic-element name="content" type="text_area" index-type="text" instance-id="qnll">
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/'/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/]/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/}/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/)/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/>/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/</" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/|/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/#/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/?/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/"/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/ /" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
@[LPS-85960](https://issues.liferay.com/browse/LPS-85960)

Incorporated the formatting changes per https://github.com/joshuacords/liferay-portal/pull/37
> This integration test checks specifically that stop characters inserted into the path of a URL in staged web content does not alter the URL, which was the issue in LPS-85960.
> 
> See previous conversation regarding this integration test here: moltam89#437