### PR TITLE
LPS-87135

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_preview.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_preview.scss
@@ -154,6 +154,8 @@
 }
 
 .lfr-preview-file-image-overlay-controls {
+	pointer-events: all;
+
 	.image-viewer-control.carousel-control {
 		&.left {
 			left: 15px;

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/preview.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/preview.js
@@ -29,9 +29,9 @@ AUI.add(
 
 		var TPL_LOADING_INDICATOR = '<div class="lfr-preview-file-loading-indicator hide">{0}&nbsp;</div>';
 
-		var TPL_MAX_ARROW_LEFT = '<a href="javascript:;" class="image-viewer-control carousel-control left lfr-preview-file-arrow">' + Liferay.Util.getLexiconIconTpl('angle-left') + '</a>';
+		var TPL_MAX_ARROW_LEFT = '<a href="javascript:;" class="image-viewer-control carousel-control carousel-control-prev left lfr-preview-file-arrow">' + Liferay.Util.getLexiconIconTpl('angle-left') + '</a>';
 
-		var TPL_MAX_ARROW_RIGHT = '<a href="javascript:;" class="image-viewer-control carousel-control right lfr-preview-file-arrow">' + Liferay.Util.getLexiconIconTpl('angle-right') + '</a>';
+		var TPL_MAX_ARROW_RIGHT = '<a href="javascript:;" class="image-viewer-control carousel-control carousel-control-next right lfr-preview-file-arrow">' + Liferay.Util.getLexiconIconTpl('angle-right') + '</a>';
 
 		var TPL_MAX_CONTROLS = '<span class="lfr-preview-file-image-overlay-controls"></span>';
 


### PR DESCRIPTION
**LPS**: https://issues.liferay.com/browse/LPS-87135

**Problem**:  After clicking the magnifying glass of a multi-page document in the Documents and Media portlet, the navigation arrows appear in the bottom left corner with improper styles and they are not clickable.  The User is unable to navigate between pages in the zoomed-in preview window.

**Solution**:

- The modal dialog of the zoomed-in preview window has the attribute [`pointer-events: none`](https://github.com/liferay/clay/blob/1a70358779cdd10bf5e99ceb0487cb0c88033b0b/packages/clay-css/src/scss/bootstrap/_modal.scss#L41).  Since the navigation arrows are child nodes of the modal dialog, they inherit this attribute and therefore are not clickable.  To make them clickable, we specify `pointer-events: all` for the class that holds the navigation arrows.
- The navigation arrows do not contain the [Clay styling for navigation controls](https://github.com/liferay/clay/blob/1a70358779cdd10bf5e99ceb0487cb0c88033b0b/packages/clay-css/src/scss/bootstrap/_carousel.scss#L63-L102) that is used for 7.1.  The styling is added by including the classes `carousel-control-prev` and `carousel-control-next`.