### PR TITLE
LPS-86364

### DIFF
--- a/modules/apps/staging/staging-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/staging/staging-lang/src/main/resources/content/Language.properties
@@ -144,6 +144,7 @@ pages-x=Pages {0}
 please-enter-a-valid-end-date-that-is-in-the-past=Please enter a valid end date that is in the past.
 please-enter-a-valid-start-date-that-is-in-the-past=Please enter a valid start date that is in the past.
 please-wait-as-the-publication-processes-on-the-remote-site=Please wait as the publication processes on the remote site.
+portlet's-schema-version-x-in-the-lar-is-not-valid-for-the-deployed-portlet-x-with-schema-version-x=Portlet's schema version {0} in the LAR is not valid for the deployed portlet {1} with schema version {2}.
 process-details=Process Details
 process-name-placeholder=Enter the name of the process (e.g. Maria's Weekly Article Publication).
 processes=Processes


### PR DESCRIPTION
**LPS**: https://issues.liferay.com/browse/LPS-86364

**Problem**: Import process fails and displays error message
`portlet's-schema-version-x-in-the-lar-is-not-valid-for-the-deployed-portlet-x-with-schema-version-x`.  However, it should display a user friendly message without '-' between each of the words.

This language key was originally added in Story Ticket [LPS-71002](https://issues.liferay.com/browse/LPS-71002) (specifically in [this commit](https://github.com/brianchandotcom/liferay-portal/pull/47946/commits/ccbd7abc2dffc9ff8a221e30f5efd51b94055d16#diff-0596d087d7b2ce65308160547483abe9R121)), and it was removed in Technical Task ticket [LPS-80618](https://issues.liferay.com/browse/LPS-80618) which re-words multiple language keys.  The removal of language key `portlet's-schema-version-x-in-the-lar-is-not-valid-for-the-deployed-portlet-x-with-schema-version-x` was done in [this commit](https://github.com/liferay/liferay-portal/commit/8ed6f6a6bea15e3d8f556c9683a18d5b28ed2e2d#diff-01ccd618cb0eddbf759a649d369d701dL141).

This was likely unintentional since it removes the string  rather than editing it or placing it in a different module.

**Solution**:  Add the language key back to the Language.properties file in the staging-lang module.