### PR TITLE
LPS-88305-test

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/exportimport/content/processor/DDMFormValuesExportImportContentProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/exportimport/content/processor/DDMFormValuesExportImportContentProcessor.java
@@ -15,6 +15,7 @@
 package com.liferay.dynamic.data.mapping.exportimport.content.processor;
 
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.dynamic.data.mapping.model.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.model.Value;
@@ -23,6 +24,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.util.DDMFormFieldValueTransformer;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesTransformer;
 import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.journal.model.JournalArticle;
@@ -43,6 +45,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Element;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -98,7 +101,7 @@ public class DDMFormValuesExportImportContentProcessor
 
 		ddmFormValuesTransformer.addTransformer(
 			new FileEntryImportDDMFormFieldValueTransformer(
-				portletDataContext));
+				portletDataContext, stagedModel));
 		ddmFormValuesTransformer.addTransformer(
 			new JournalArticleImportDDMFormFieldValueTransformer(
 				portletDataContext));
@@ -273,9 +276,10 @@ public class DDMFormValuesExportImportContentProcessor
 		implements DDMFormFieldValueTransformer {
 
 		public FileEntryImportDDMFormFieldValueTransformer(
-			PortletDataContext portletDataContext) {
+			PortletDataContext portletDataContext, StagedModel stagedModel) {
 
 			_portletDataContext = portletDataContext;
+			_stagedModel = stagedModel;
 		}
 
 		@Override
@@ -309,35 +313,70 @@ public class DDMFormValuesExportImportContentProcessor
 		}
 
 		protected FileEntry fetchImportedFileEntry(
-				PortletDataContext portletDataContext, JSONObject jsonObject)
+			PortletDataContext portletDataContext, JSONObject jsonObject)
 			throws PortalException {
 
 			Map<Long, Long> groupIds =
 				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 					Group.class);
 
-			long groupId = jsonObject.getLong("groupId");
+			Long groupId = jsonObject.getLong("groupId");
 			String uuid = jsonObject.getString("uuid");
 
-			groupId = MapUtil.getLong(groupIds, groupId, groupId);
+			FileEntry fileEntry = null;
 
-			if ((groupId > 0) && Validator.isNotNull(uuid)) {
-				try {
-					return _dlAppService.getFileEntryByUuidAndGroupId(
-						uuid, groupId);
+			if (ExportImportThreadLocal.isImportInProcess()) {
+				List<Element> referenceElements =
+					portletDataContext.getReferenceElements(
+						_stagedModel, DLFileEntry.class);
+
+				Map<Long, Long> dlFileEntryIds =
+					(Map<Long, Long>) portletDataContext.getNewPrimaryKeysMap(
+						DLFileEntry.class);
+
+				for (Element referenceElement : referenceElements) {
+					Long classPK = GetterUtil.getLong(
+						referenceElement.attributeValue("class-pk"));
+
+					long referenceElementGroupId = GetterUtil.getLong(
+						referenceElement.attributeValue("group-id"));
+
+					String referenceElementUuid = GetterUtil.getString(
+						referenceElement.attributeValue("uuid"));
+
+					if (groupId.equals(referenceElementGroupId) &&
+						uuid.equals(referenceElementUuid)) {
+
+						long fileEntryId = MapUtil.getLong(
+							dlFileEntryIds, classPK, classPK);
+
+						fileEntry = _dlAppService.getFileEntry(
+							fileEntryId);
+					}
 				}
-				catch (NoSuchFileEntryException nsfee) {
-					if (_log.isWarnEnabled()) {
-						_log.warn(
-							StringBundler.concat(
-								"Unable to find file entry with uuid ", uuid,
-								" and groupId ", groupId),
-							nsfee);
+			}
+			else {
+				groupId = MapUtil.getLong(groupIds, groupId, groupId);
+
+				if ((groupId > 0) && Validator.isNotNull(uuid)) {
+					try {
+						fileEntry =
+							_dlAppService.getFileEntryByUuidAndGroupId(
+								uuid, groupId);
+					}
+					catch (NoSuchFileEntryException nsfee) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(
+								StringBundler.concat(
+									"Unable to find file entry with uuid ", uuid,
+									" and groupId ", groupId),
+								nsfee);
+						}
 					}
 				}
 			}
 
-			return null;
+			return fileEntry;
 		}
 
 		protected String toJSON(FileEntry fileEntry, String type) {
@@ -352,6 +391,7 @@ public class DDMFormValuesExportImportContentProcessor
 		}
 
 		private final PortletDataContext _portletDataContext;
+		private final StagedModel _stagedModel;
 
 	}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -24,6 +24,7 @@ import com.liferay.dynamic.data.mapping.storage.Fields;
 import com.liferay.dynamic.data.mapping.util.DDM;
 import com.liferay.dynamic.data.mapping.util.DDMFieldsCounter;
 import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.journal.exception.ArticleContentException;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
@@ -561,10 +562,13 @@ public class JournalConverterImpl implements JournalConverter {
 				JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 					dynamicContentElement.getText());
 
-				String uuid = jsonObject.getString("uuid");
-				long groupId = jsonObject.getLong("groupId");
+				if (!ExportImportThreadLocal.isImportInProcess()) {
+					String uuid = jsonObject.getString("uuid");
+					long groupId = jsonObject.getLong("groupId");
 
-				_dlAppLocalService.getFileEntryByUuidAndGroupId(uuid, groupId);
+					_dlAppLocalService.getFileEntryByUuidAndGroupId(
+						uuid, groupId);
+				}
 
 				serializable = jsonObject.toString();
 			}


### PR DESCRIPTION
Follow the steps from [LPS-88833](https://issues.liferay.com/browse/LPS-88833) to create a LAR file for testing this fix.

For testing, we will use the debugger to return corrupted content for https://github.com/joshuacords/liferay-portal/commit/09dddc2c3bba10cc9505ac972e8246f08bf41a91#diff-e0d888f69fe144e5831bc57dea943edbR562

1. Delete any previously existing sites and create a new site Site1 and navigate to it.
2. Enable debugging on IntelliJ.  Set a break point at https://github.com/joshuacords/liferay-portal/commit/09dddc2c3bba10cc9505ac972e8246f08bf41a91#diff-e0d888f69fe144e5831bc57dea943edbR562.
2. Go to Publishing > Import.  Select the LAR from [LPS-88833](https://issues.liferay.com/browse/LPS-88833) and click Continue.  In the Update Data section, select the "Copy as New" strategy and then click Import.
4. In the debugger's variables, select `dynamicContentElement` > `_node` > `content` > `text`.  Right-click on `text` and select Set Value.  Paste the following invalid data:
```"{\"groupId\":\"55555\",\"title\":\"bad-file-name.png\",\"type\":\"bad-document\",\"uuid\":\"4a914f0f-xxxx-xxxx-7ae9-6f1814f7a3ec\"}"```
Confirm that the data persists in the debugger's variable viewer.
![lps-88305-test](https://user-images.githubusercontent.com/38436716/50941171-a7f3af00-1438-11e9-831f-259c255f547a.png)

5. Resume debugging.

Expected Result: There are no exceptions thrown involving the corrupted data.