### PR TITLE
LPS-90372

### DIFF
--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
@@ -52,6 +52,7 @@ import javax.portlet.RenderResponse;
 
 import org.apache.felix.service.command.CommandProcessor;
 import org.apache.felix.service.command.CommandSession;
+import org.apache.felix.service.command.Converter;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -128,7 +129,12 @@ public class GogoShellPortlet extends MVCPortlet {
 
 			checkCommand(command, themeDisplay);
 
-			commandSession.execute(command);
+			Object result = commandSession.execute(command);
+
+			if (result != null) {
+				outputPrintStream.print(
+					commandSession.format(result, Converter.INSPECT));
+			}
 
 			outputPrintStream.flush();
 			errorPrintStream.flush();


### PR DESCRIPTION
**LPS**: https://issues.liferay.com/browse/LPS-90372

**Problem**: When attempting to run scr commands (e.g. scr:list, scr:config) from the Gogo Shell Portlet, no output is generated in the UI.  This began to occur after Liferay's update to a newer version of the org.apache.felix.scr third-party dependency in [LPS-86015](https://issues.liferay.com/browse/LPS-86015) which is part of Story Ticket [LPS-85319](https://issues.liferay.com/browse/LPS-85319).

In this newer version of org.apache.felix.scr, several SCR methods were rewritten.  The change that specifically affected output to the Gogo Shell portlet was a change in the returnType for certain methods.

Below are some of the findings from [PTR-606](https://issues.liferay.com/browse/PTR-606).

> The main thing to note is that before the update, the method had a returnType **void** and the output was provided via **System.out**.
> The new code has a returnType of **ComponentDescriptionDTO[]** and the output is no longer provided via **System.out**.

**Solution**:  Update the Gogo Shell Portlet to handle results returned as an Object.

Relevant findings from [PTR-606](https://issues.liferay.com/browse/PTR-606).
> Since the output is no longer provided via System.out, Liferay's Gogo Shell portlet is no longer showing any results.
> ...
> The reason for this is because Liferay's current logic does not handle results that are returned as an object.
> Here is a comparison between Gogo Shell's Console (via telnet) vs Liferay Gogo Shell portlet on how results are handled:
> - Gogo Shell Console: [Console.java#L66-L73](https://github.com/apache/felix/blob/trunk/gogo/shell/src/main/java/org/apache/felix/gogo/shell/Console.java#L66-L73)
> - Liferay's Gogo Shell Portlet: [GogoShellPortlet.java#L135](https://github.com/liferay/liferay-portal/blob/7.1.1-ga2/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java#L135)
>
> As you can see, Liferay's Gogo Shell portlet does not handle the returned Object from the executed command.
