### PR TITLE
LPS-90456

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/select/select_search_support.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/select/select_search_support.js
@@ -100,7 +100,7 @@ AUI.add(
 
 				new renderer(context, container);
 
-				return container.firstElementChild.innerHTML;
+				return container.firstChild.innerHTML;
 			},
 
 			_renderList: function(options, showPlaceholderOption) {


### PR DESCRIPTION
**LPS**: https://issues.liferay.com/browse/LPS-90456

**Problem**: Unable to search for elements in the Data Provider drop down list for Forms in IE because `.firstElementChild` is not supported for IE9+.  [See documentation](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/firstElementChild#Browser_compatibility).

The `_renderList` function that is used in searching is unable to successfully complete because it performs a function call on `_getTemplate`, which attempts to use `.firstElementChild`.

**Solution**:  Replace `.firstElementChild` with `.firstChild`.