### PR TITLE
LPS-112882 Apply permission filter to total results

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
@@ -217,6 +217,19 @@ public class DefaultSearchResultPermissionFilter
 				PropsKeys.INDEX_PERMISSION_FILTER_SEARCH_AMPLIFICATION_FACTOR));
 	}
 
+	private int _getFilteredHitsSize(SearchContext searchContext) {
+		searchContext.setStart(QueryUtil.ALL_POS);
+		searchContext.setEnd(QueryUtil.ALL_POS);
+
+		Hits hits = getHits(searchContext);
+
+		filterHits(hits, searchContext);
+
+		Document[] documents = hits.getDocs();
+
+		return documents.length;
+	}
+
 	private boolean _isIncludeDocument(
 		Document document, long companyId, boolean companyAdmin, int status) {
 
@@ -302,7 +315,6 @@ public class DefaultSearchResultPermissionFilter
 			int amplifiedCount =
 				_permissionFilteredSearchResultAccurateCountThreshold;
 			double amplificationFactor = 1.0;
-			int excludedDocsSize = 0;
 			int filteredDocsCount = 0;
 			int hitsSize = 0;
 			int offset = 0;
@@ -341,8 +353,6 @@ public class DefaultSearchResultPermissionFilter
 
 				Document[] newDocs = hits.getDocs();
 
-				excludedDocsSize += oldDocs.length - newDocs.length;
-
 				filteredDocsCount += newDocs.length;
 
 				collectHits(hits, filteredDocsCount, start, end);
@@ -353,7 +363,8 @@ public class DefaultSearchResultPermissionFilter
 
 					updateDocuments(filteredDocsCount, start, end);
 
-					updateHits(hits, hitsSize - excludedDocsSize, startTime);
+					updateHits(
+						hits, _getFilteredHitsSize(searchContext), startTime);
 
 					return hits;
 				}


### PR DESCRIPTION
/cc @amandaaakwok

Notes from Amanda:
> [LPS-112882](https://issues.liferay.com/browse/LPS-112882)
> 
> **Issue:** When pagination is set, the search results show an incorrect number of total entries for users who have limited view permissions
> 
> **Scenario:** Assume we have a total of 16 documents all with a description of "issue",  limit the permission of 2 of those documents to a specific role (role B), and perform a search of "issue" while logged in as a user without role B. 
> 
> If delta is set to 4 and we navigate to page 2, `hit` will hold documents 0-7, but the number of hits will remain 16. In https://github.com/amandaaakwok/liferay-portal/blob/f2ec395a77e3a26b19e1398c641984b22dd7b8e4/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java#L134, the permission filter is applied only to documents 0-7 and not documents 8-15; the portal isn't configured to check to see if the user has permission to view the second range (8-15). This proves to be problematic when calculating the total for the search container, where the total number of results displayed (16) does not reflect the total number of results that the user has permission to see (14).
> 
> **Solution:** Apply the filter on the total number of documents rather than just the ones set by pagination