### PR TITLE
LPS-117968 Changing a Web Content article's template removes some of its categories

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
@@ -42,6 +42,7 @@ import com.liferay.taglib.aui.AUIUtil;
 import com.liferay.taglib.util.IncludeTag;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -214,12 +215,14 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 				}
 
 				if (!_ignoreRequestValue) {
-					String categoryIdsParam = request.getParameter(
+					String[] categoryIdsParam = request.getParameterValues(
 						_hiddenInput + StringPool.UNDERLINE +
 							vocabulary.getVocabularyId());
 
 					if (Validator.isNotNull(categoryIdsParam)) {
-						categoryIds = categoryIdsParam;
+						categoryIds = Arrays.toString(categoryIdsParam);
+						categoryIds = categoryIds.substring(
+							1, categoryIds.length() - 1);
 					}
 				}
 

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
@@ -35,6 +35,7 @@ import com.liferay.taglib.aui.AUIUtil;
 import com.liferay.taglib.util.IncludeTag;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -238,6 +239,8 @@ public class AssetTagsSelectorTag extends IncludeTag {
 	}
 
 	protected List<String> getTagNames() {
+		String tagNames = _tagNames;
+
 		if (Validator.isNotNull(_className) && (_classPK > 0)) {
 			List<AssetTag> tags = AssetTagServiceUtil.getTags(
 				_className, _classPK);
@@ -246,14 +249,15 @@ public class AssetTagsSelectorTag extends IncludeTag {
 		}
 
 		if (!_ignoreRequestValue) {
-			String curTagsParam = request.getParameter(_hiddenInput);
+			String[] curTagsParam = request.getParameterValues(_hiddenInput);
 
 			if (Validator.isNotNull(curTagsParam)) {
-				return StringUtil.split(curTagsParam);
+				tagNames = Arrays.toString(curTagsParam);
+				tagNames = tagNames.substring(1, tagNames.length() - 1);
 			}
 		}
 
-		return StringUtil.split(_tagNames);
+		return StringUtil.split(tagNames);
 	}
 
 	@Override


### PR DESCRIPTION
The issue was starting 72x, LPS-90509 changed the way asset category Ids and tag's name get stored. We used to store all of them in the first index of an array. However, starting 72x, each category ids/tag name get stored in its own index. Therefore, when retrieve asset category Ids and tags name, the method being used only return the first index of the array. This is the reason why when changing a Web Content article's template, only one category ID and one tag name remain display while the rest disappear. To fix this issue, I changed to call a different method that return the whole array instead.