### PR TITLE
LPS-119020 Add defaultLanguageId to taglib for Web Content title

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -136,6 +136,9 @@
 
 			var ddmFormDefinition = <%= DDMUtil.getDDMFormJSONString(ddmForm) %>;
 
+			ddmFormDefinition.defaultLanguageId =
+				'<%= LocaleUtil.toLanguageId(defaultLocale) %>';
+
 			var liferayDDMForm = Liferay.component(
 				'<portlet:namespace /><%= HtmlUtil.escapeJS(fieldsNamespace) %>ddmForm',
 				new Liferay.DDM.Form({


### PR DESCRIPTION
In LPS-119020, LPS-115891, LPP-38436, when change default language, DL and Web Content unable to create new article and upload new file. This is because defaultLanguageId wasn't sent to taglib. Therefore, I fixed this by adding defaultLanguageId to taglib.