### PR TITLE
Do not transform sql when reindexing because we need to return all re…

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.search.internal.indexer;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.configuration.Filter;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -188,7 +189,12 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 						_modelSearchSettings.getClassName(),
 						_indexerDocumentBuilder));
 
+				long ctCollectionThreadLocalCTCollectionId = CTCollectionThreadLocal.getCTCollectionId();
+
 				try {
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						CTCollectionThreadLocal.CT_COLLECTION_IDS_ALL);
+
 					batchIndexingActionable.performActions();
 				}
 				catch (Exception exception) {
@@ -200,6 +206,10 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 								" for company: ", companyId),
 							exception);
 					}
+				}
+				finally {
+					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+						ctCollectionThreadLocalCTCollectionId);
 				}
 			}
 		}

--- a/modules/apps/static/portal/portal-change-tracking/src/main/java/com/liferay/portal/change/tracking/internal/CTSQLTransformerImpl.java
+++ b/modules/apps/static/portal/portal-change-tracking/src/main/java/com/liferay/portal/change/tracking/internal/CTSQLTransformerImpl.java
@@ -235,6 +235,10 @@ public class CTSQLTransformerImpl implements CTSQLTransformer {
 	public String transform(String sql) {
 		long ctCollectionId = CTCollectionThreadLocal.getCTCollectionId();
 
+		if (ctCollectionId == CTCollectionThreadLocal.CT_COLLECTION_IDS_ALL) {
+			return sql;
+		}
+
 		String transformedSQL = null;
 
 		String key = _getTransformedSQLKey(ctCollectionId, sql);

--- a/portal-kernel/src/com/liferay/portal/kernel/change/tracking/CTCollectionThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/change/tracking/CTCollectionThreadLocal.java
@@ -25,6 +25,8 @@ public class CTCollectionThreadLocal {
 
 	public static final long CT_COLLECTION_ID_PRODUCTION = 0;
 
+	public static final long CT_COLLECTION_IDS_ALL = -1;
+
 	public static long getCTCollectionId() {
 		return _ctCollectionId.get();
 	}


### PR DESCRIPTION
Steps to reproduce:

1. Enable publications
2. Create two publications P1 and P2
3. In each publication create a web content (test1 and test2 respectively)
4. Run a search reindex for Journal Article while checked out to P1
5. For each publication: Go to Content -> Web Content and search for test
**Expected behavior:** Both publications should show their respective web content in the search results
**Actual behavior:** Only P1's web content is searchable
6. Run a full search reindex  while checked out to P1
7. Repeat step 5
**Expected behavior:** Both publications should show their respective web content in the search results
**Actual behavior:** Neither publication's web content is searchable

I used web content in the steps but this applies to any asset