### PR TITLE
LPS-00000 Sanitize asset list type settings when editing/exporting

### DIFF
--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/util/AssetListTypeSettingsSanitizerUtil.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/util/AssetListTypeSettingsSanitizerUtil.java
@@ -1,0 +1,147 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.util;
+
+import com.liferay.asset.list.service.AssetListEntryLocalServiceUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Joshua Cords
+ */
+public class AssetListTypeSettingsSanitizerUtil {
+
+    public static UnicodeProperties sanitize(
+        long assetListEntryId, long segmentsEntryId,
+        UnicodeProperties unicodeProperties) {
+
+        if (unicodeProperties == null) {
+            return new UnicodeProperties();
+        }
+
+        boolean updated = false;
+
+        updated |= _sanitizeClassNameIds(
+            assetListEntryId, segmentsEntryId, unicodeProperties);
+        updated |= _sanitizeAnyAssetType(
+            assetListEntryId, segmentsEntryId, unicodeProperties);
+
+        if (updated) {
+            try {
+                AssetListEntryLocalServiceUtil.updateAssetListEntryTypeSettings(
+                    assetListEntryId, segmentsEntryId,
+                    unicodeProperties.toString());
+            }
+            catch (PortalException portalException) {
+                if (_log.isWarnEnabled()) {
+                    _log.warn(
+                        "Unable to persist sanitized type settings for " +
+                            "asset list " + assetListEntryId +
+                                " and segments entry " + segmentsEntryId,
+                        portalException);
+                }
+            }
+        }
+
+        return unicodeProperties;
+    }
+
+    private static void _logRemoval(
+        long assetListEntryId, long segmentsEntryId, long classNameId) {
+
+        if (!_log.isInfoEnabled()) {
+            return;
+        }
+
+        _log.info(
+            String.format(
+                "Removed missing class name id %d from asset list %d (segments " +
+                    "entry %d)",
+                classNameId, assetListEntryId, segmentsEntryId));
+    }
+
+    private static boolean _sanitizeAnyAssetType(
+        long assetListEntryId, long segmentsEntryId,
+        UnicodeProperties unicodeProperties) {
+
+        long classNameId = GetterUtil.getLong(
+            unicodeProperties.getProperty("anyAssetType"));
+
+        if (classNameId <= 0) {
+            return false;
+        }
+
+        if (ClassNameLocalServiceUtil.fetchClassName(classNameId) != null) {
+            return false;
+        }
+
+        unicodeProperties.remove("anyAssetType");
+
+        _logRemoval(assetListEntryId, segmentsEntryId, classNameId);
+
+        return true;
+    }
+
+    private static boolean _sanitizeClassNameIds(
+        long assetListEntryId, long segmentsEntryId,
+        UnicodeProperties unicodeProperties) {
+
+        String[] values = StringUtil.split(
+            unicodeProperties.getProperty("classNameIds"));
+
+        if (values.length == 0) {
+            return false;
+        }
+
+        List<String> validValues = new ArrayList<>(values.length);
+
+        boolean updated = false;
+
+        for (String value : values) {
+            long classNameId = GetterUtil.getLong(value);
+
+            if (classNameId <= 0) {
+                continue;
+            }
+
+            if (ClassNameLocalServiceUtil.fetchClassName(classNameId) != null) {
+                validValues.add(String.valueOf(classNameId));
+
+                continue;
+            }
+
+            updated = true;
+
+            _logRemoval(assetListEntryId, segmentsEntryId, classNameId);
+        }
+
+        if (!updated) {
+            return false;
+        }
+
+        if (validValues.isEmpty()) {
+            unicodeProperties.remove("classNameIds");
+        }
+        else {
+            unicodeProperties.setProperty(
+                "classNameIds", StringUtil.merge(validValues));
+        }
+
+        return true;
+    }
+
+    private static final Log _log = LogFactoryUtil.getLog(
+        AssetListTypeSettingsSanitizerUtil.class);
+
+}

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/exportimport/content/processor/AssetListEntryExportImportContentProcessor.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/exportimport/content/processor/AssetListEntryExportImportContentProcessor.java
@@ -9,6 +9,8 @@ import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.asset.list.util.AssetListTypeSettingsSanitizerUtil;
 import com.liferay.asset.util.AssetRendererFactoryClassProvider;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
@@ -35,6 +37,7 @@ import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.site.model.adapter.StagedGroup;
+import com.liferay.segments.constants.SegmentsEntryConstants;
 
 import java.util.Arrays;
 import java.util.List;
@@ -61,9 +64,22 @@ public class AssetListEntryExportImportContentProcessor
 			boolean escapeContent)
 		throws Exception {
 
-		UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.load(
-			content
-		).build();
+                UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.load(
+                        content
+                ).build();
+
+                long assetListEntryId = 0;
+
+                if (stagedModel instanceof AssetListEntry assetListEntry) {
+                        assetListEntryId = assetListEntry.getAssetListEntryId();
+                }
+
+                long segmentsEntryId = GetterUtil.getLong(
+                        unicodeProperties.getProperty("segmentsEntryId"),
+                        SegmentsEntryConstants.ID_DEFAULT);
+
+                unicodeProperties = AssetListTypeSettingsSanitizerUtil.sanitize(
+                        assetListEntryId, segmentsEntryId, unicodeProperties);
 
 		long[] groupIds = GetterUtil.getLongValues(
 			StringUtil.split(unicodeProperties.getProperty("groupIds", null)));

--- a/modules/apps/asset/asset-list-test/src/test/java/com/liferay/asset/list/util/AssetListTypeSettingsSanitizerUtilTest.java
+++ b/modules/apps/asset/asset-list-test/src/test/java/com/liferay/asset/list/util/AssetListTypeSettingsSanitizerUtilTest.java
@@ -1,0 +1,167 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.util;
+
+import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.asset.list.service.AssetListEntryLocalServiceUtil;
+import com.liferay.portal.kernel.module.service.Snapshot;
+import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Joshua Cords
+ */
+public class AssetListTypeSettingsSanitizerUtilTest {
+
+    @ClassRule
+    @Rule
+    public static final LiferayUnitTestRule liferayUnitTestRule =
+        LiferayUnitTestRule.INSTANCE;
+
+    @ClassRule
+    public static final CodeCoverageAssertor codeCoverageAssertor =
+        new CodeCoverageAssertor();
+
+    @AfterClass
+    public static void tearDownClass() {
+        if (_assetListEntryLocalServiceSnapshot != null) {
+            ReflectionTestUtil.setFieldValue(
+                AssetListEntryLocalServiceUtil.class, "_serviceSnapshot",
+                _assetListEntryLocalServiceSnapshot);
+        }
+    }
+
+    @After
+    public void tearDown() {
+        if (_classNameLocalServiceUtilMockedStatic != null) {
+            _classNameLocalServiceUtilMockedStatic.close();
+        }
+    }
+
+    @Before
+    public void setUp() {
+        _assetListEntryLocalService = Mockito.mock(
+            AssetListEntryLocalService.class);
+
+        if (_assetListEntryLocalServiceSnapshot == null) {
+            _assetListEntryLocalServiceSnapshot = ReflectionTestUtil.getFieldValue(
+                AssetListEntryLocalServiceUtil.class, "_serviceSnapshot");
+        }
+
+        ReflectionTestUtil.setFieldValue(
+            AssetListEntryLocalServiceUtil.class, "_serviceSnapshot",
+            new Snapshot<AssetListEntryLocalService>(
+                AssetListEntryLocalServiceUtil.class,
+                AssetListEntryLocalService.class) {
+
+                @Override
+                public AssetListEntryLocalService get() {
+                    return _assetListEntryLocalService;
+                }
+
+            });
+
+        _classNameLocalServiceUtilMockedStatic = Mockito.mockStatic(
+            ClassNameLocalServiceUtil.class);
+    }
+
+    @Test
+    public void testSanitizeRemovesMissingAnyAssetType() throws Exception {
+        long assetListEntryId = _randomPositiveLong();
+        long segmentsEntryId = _randomPositiveLong();
+        long classNameId = _randomPositiveLong();
+
+        _classNameLocalServiceUtilMockedStatic.when(
+            () -> ClassNameLocalServiceUtil.fetchClassName(classNameId)
+        ).thenReturn(
+            null
+        );
+
+        UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.put(
+            "anyAssetType", classNameId
+        ).build();
+
+        UnicodeProperties sanitizedUnicodeProperties =
+            AssetListTypeSettingsSanitizerUtil.sanitize(
+                assetListEntryId, segmentsEntryId, unicodeProperties);
+
+        Assert.assertNull(
+            sanitizedUnicodeProperties.getProperty("anyAssetType"));
+
+        Mockito.verify(
+            _assetListEntryLocalService
+        ).updateAssetListEntryTypeSettings(
+            assetListEntryId, segmentsEntryId,
+            sanitizedUnicodeProperties.toString());
+    }
+
+    @Test
+    public void testSanitizeRemovesMissingClassNameIds() throws Exception {
+        long assetListEntryId = _randomPositiveLong();
+        long segmentsEntryId = _randomPositiveLong();
+        long missingClassNameId = _randomPositiveLong();
+        long validClassNameId = _randomPositiveLong();
+
+        _classNameLocalServiceUtilMockedStatic.when(
+            () -> ClassNameLocalServiceUtil.fetchClassName(validClassNameId)
+        ).thenReturn(
+            new Object()
+        );
+
+        _classNameLocalServiceUtilMockedStatic.when(
+            () -> ClassNameLocalServiceUtil.fetchClassName(missingClassNameId)
+        ).thenReturn(
+            null
+        );
+
+        UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.put(
+            "classNameIds",
+            missingClassNameId + "," + validClassNameId
+        ).build();
+
+        UnicodeProperties sanitizedUnicodeProperties =
+            AssetListTypeSettingsSanitizerUtil.sanitize(
+                assetListEntryId, segmentsEntryId, unicodeProperties);
+
+        Assert.assertEquals(
+            String.valueOf(validClassNameId),
+            sanitizedUnicodeProperties.getProperty("classNameIds"));
+
+        Mockito.verify(
+            _assetListEntryLocalService
+        ).updateAssetListEntryTypeSettings(
+            assetListEntryId, segmentsEntryId,
+            sanitizedUnicodeProperties.toString());
+    }
+
+    private static Snapshot<AssetListEntryLocalService>
+        _assetListEntryLocalServiceSnapshot;
+
+    private long _randomPositiveLong() {
+        return Math.max(1, Math.abs(RandomTestUtil.randomLong()));
+    }
+
+    private AssetListEntryLocalService _assetListEntryLocalService;
+    private MockedStatic<ClassNameLocalServiceUtil>
+        _classNameLocalServiceUtilMockedStatic;
+
+}

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/AssetListPortlet.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/AssetListPortlet.java
@@ -11,6 +11,7 @@ import com.liferay.asset.list.constants.AssetListPortletKeys;
 import com.liferay.asset.list.exception.AssetListEntryTitleException;
 import com.liferay.asset.list.exception.DuplicateAssetListEntryTitleException;
 import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.asset.list.util.AssetListTypeSettingsSanitizerUtil;
 import com.liferay.asset.list.web.internal.constants.AssetListWebKeys;
 import com.liferay.asset.list.web.internal.display.context.AssetListDisplayContext;
 import com.liferay.asset.list.web.internal.display.context.AssetListItemsDisplayContext;
@@ -140,14 +141,19 @@ public class AssetListPortlet extends MVCPortlet {
 		AssetListEntry assetListEntry =
 			assetListDisplayContext.getAssetListEntry();
 
-		if (assetListEntry == null) {
-			return new UnicodeProperties();
-		}
+                if (assetListEntry == null) {
+                        return new UnicodeProperties();
+                }
 
-		return UnicodePropertiesBuilder.load(
-			assetListEntry.getTypeSettings(
-				assetListDisplayContext.getSegmentsEntryId())
-		).build();
+                UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.load(
+                        assetListEntry.getTypeSettings(
+                                assetListDisplayContext.getSegmentsEntryId())
+                ).build();
+
+                return AssetListTypeSettingsSanitizerUtil.sanitize(
+                        assetListEntry.getAssetListEntryId(),
+                        assetListDisplayContext.getSegmentsEntryId(),
+                        unicodeProperties);
 	}
 
 	@Reference


### PR DESCRIPTION
## Summary
- add an AssetListTypeSettingsSanitizerUtil that removes missing class name ids, logs removals, and persists cleaned type settings
- sanitize collection type settings before rendering the edit UI and before export processing to avoid runtime failures
- cover the sanitizer utility with unit tests to ensure missing ids are pruned and updates are persisted

## Testing
- `./gradlew formatSource -PprojectPath=:apps:asset:asset-list-api` *(fails: Gradle distribution zip unavailable in container)*