### PR TITLE
Add sidecar development mode property

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/Sidecar.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/Sidecar.java
@@ -416,26 +416,28 @@ public class Sidecar {
 				"bootstrap=ALL-UNNAMED");
 		arguments.add("--module-path=" + _sidecarHomePath.resolve("lib"));
 
-		// Apply agent to load modified classes
+		if (!PropsValues.SIDECAR_DEVELOPMENT_MODE_ENABLE) {
+			// Apply agent to load modified classes
 
-		Path agentPath = null;
+			Path agentPath = null;
 
-		URL sidecarAgentBundleURL = _getBundleURL(SidecarAgent.class);
+			URL sidecarAgentBundleURL = _getBundleURL(SidecarAgent.class);
 
-		try {
-			agentPath = Path.of(sidecarAgentBundleURL.toURI());
-		}
-		catch (URISyntaxException uriSyntaxException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(uriSyntaxException);
+			try {
+				agentPath = Path.of(sidecarAgentBundleURL.toURI());
+			}
+			catch (URISyntaxException uriSyntaxException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(uriSyntaxException);
+				}
+
+				File file = new File(sidecarAgentBundleURL.getPath());
+
+				agentPath = file.toPath();
 			}
 
-			File file = new File(sidecarAgentBundleURL.getPath());
-
-			agentPath = file.toPath();
+			arguments.add("-javaagent:" + agentPath);
 		}
-
-		arguments.add("-javaagent:" + agentPath);
 
 		return arguments;
 	}
@@ -579,6 +581,10 @@ public class Sidecar {
 			_sidecarHomePath
 		).build(
 		).install();
+
+		if (PropsValues.SIDECAR_DEVELOPMENT_MODE_ENABLE) {
+			return;
+		}
 
 		Path modulesPath = _sidecarHomePath.resolve(
 			_SIDECAR_MODULES_FOLDER_NAME);

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5641,6 +5641,16 @@
     #
     index.sortable.text.fields.truncated.length=255
 
+    #
+    # Set this to true to keep all Elasticsearch modules enabled when starting
+    # the Sidecar Elasticsearch instance for development (for example, to allow
+    # Kibana connections). By default, nonessential modules are disabled for
+    # faster startup.
+    #
+    # Env: LIFERAY_SIDECAR_PERIOD_DEVELOPMENT_PERIOD_MODE_PERIOD_ENABLE
+    #
+    sidecar.development.mode.enable=false
+
 ##
 ## Setup Wizard
 ##

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2429,6 +2429,9 @@ public interface PropsKeys {
 	public static final String SHUTDOWN_PROGRAMMATICALLY_EXIT =
 		"shutdown.programmatically.exit";
 
+	public static final String SIDECAR_DEVELOPMENT_MODE_ENABLE =
+		"sidecar.development.mode.enable";
+
 	public static final String SITEMAP_DISPLAY_TEMPLATES_CONFIG =
 		"sitemap.display.templates.config";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -2107,6 +2107,10 @@ public class PropsValues {
 	public static boolean SETUP_WIZARD_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.SETUP_WIZARD_ENABLED));
 
+	public static final boolean SIDECAR_DEVELOPMENT_MODE_ENABLE =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.SIDECAR_DEVELOPMENT_MODE_ENABLE));
+
 	public static final String SITEMAP_DISPLAY_TEMPLATES_CONFIG = PropsUtil.get(
 		PropsKeys.SITEMAP_DISPLAY_TEMPLATES_CONFIG);
 


### PR DESCRIPTION
## Summary
- add a sidecar.development.mode.enable portal property and expose it through PropsKeys/PropsValues
- keep Elasticsearch sidecar modules and skip the javaagent when the development property is enabled

## Testing
- ./gradlew formatSource *(fails: Gradle distribution zip missing in tools directory)*
- ~/.gradle/wrapper/dists/gradle-8.5-bin/5t9huq95ubn472n8rpzujfbqh/gradle-8.5/bin/gradle -p modules formatSource *(fails: repository access returned HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943466f2b80832fb1848cb767140d70)