### PR TITLE
Handle company ids as lists for reindex background tasks

### DIFF
--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/action/EditMVCActionCommand.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/action/EditMVCActionCommand.java
@@ -38,9 +38,13 @@ import jakarta.portlet.PortletSession;
 
 import java.io.Serializable;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import java.util.stream.Collectors;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -208,30 +212,40 @@ public class EditMVCActionCommand extends BaseMVCActionCommand {
 		dictionaryReindexer.reindexDictionaries(companyIds);
 	}
 
-	private void _reindexIndexReindexer(
-			String className, long[] companyIds, String executionMode,
-			ThemeDisplay themeDisplay)
-		throws Exception {
+        private void _reindexIndexReindexer(
+                        String className, long[] companyIds, String executionMode,
+                        ThemeDisplay themeDisplay)
+                throws Exception {
 
-		_backgroundTaskManager.addBackgroundTask(
-			themeDisplay.getUserId(), BackgroundTaskConstants.GROUP_ID_DEFAULT,
-			"reindexIndexReindexer",
-			_CLASS_NAME_REINDEX_INDEX_REINDEXER_BACKGROUND_TASK_EXECUTOR,
-			HashMapBuilder.<String, Serializable>put(
-				BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS, true
-			).put(
-				ReindexBackgroundTaskConstants.CLASS_NAME, className
-			).put(
-				ReindexBackgroundTaskConstants.COMPANY_IDS, companyIds
-			).put(
-				ReindexBackgroundTaskConstants.EXECUTION_MODE, executionMode
-			).build(),
-			new ServiceContext());
-	}
+                _backgroundTaskManager.addBackgroundTask(
+                        themeDisplay.getUserId(), BackgroundTaskConstants.GROUP_ID_DEFAULT,
+                        "reindexIndexReindexer",
+                        _CLASS_NAME_REINDEX_INDEX_REINDEXER_BACKGROUND_TASK_EXECUTOR,
+                        HashMapBuilder.<String, Serializable>put(
+                                BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS, true
+                        ).put(
+                                ReindexBackgroundTaskConstants.CLASS_NAME, className
+                        ).put(
+                                ReindexBackgroundTaskConstants.COMPANY_IDS,
+                                _toCompanyIds(companyIds)
+                        ).put(
+                                ReindexBackgroundTaskConstants.EXECUTION_MODE, executionMode
+                        ).build(),
+                        new ServiceContext());
+        }
 
-	private static final String
-		_CLASS_NAME_REINDEX_INDEX_REINDEXER_BACKGROUND_TASK_EXECUTOR =
-			"com.liferay.portal.search.internal.background.task." +
+        private List<Long> _toCompanyIds(long[] companyIds) {
+                return Arrays.stream(
+                        companyIds
+                ).boxed(
+                ).collect(
+                        Collectors.toList()
+                );
+        }
+
+        private static final String
+                _CLASS_NAME_REINDEX_INDEX_REINDEXER_BACKGROUND_TASK_EXECUTOR =
+                        "com.liferay.portal.search.internal.background.task." +
 				"ReindexIndexReindexerBackgroundTaskExecutor";
 
 	@Reference

--- a/modules/apps/portal-search/portal-search-test/src/test/java/com/liferay/portal/search/internal/background/task/ReindexIndexReindexerBackgroundTaskExecutorTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/test/java/com/liferay/portal/search/internal/background/task/ReindexIndexReindexerBackgroundTaskExecutorTest.java
@@ -5,15 +5,25 @@
 
 package com.liferay.portal.search.internal.background.task;
 
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.search.background.task.ReindexBackgroundTaskConstants;
 import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSender;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.search.spi.reindexer.IndexReindexerRegistry;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.io.Serializable;
+
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,12 +44,12 @@ public class ReindexIndexReindexerBackgroundTaskExecutorTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Before
-	public void setUp() {
-		_reindexIndexReindexerBackgroundTaskExecutor =
-			new ReindexIndexReindexerBackgroundTaskExecutor();
+        public void setUp() {
+                _reindexIndexReindexerBackgroundTaskExecutor =
+                        new ReindexIndexReindexerBackgroundTaskExecutor();
 
-		Collection<IndexReindexer> indexReindexers = Arrays.asList(
-			_indexReindexer1, _indexReindexer2);
+                Collection<IndexReindexer> indexReindexers = Arrays.asList(
+                        _indexReindexer1, _indexReindexer2);
 
 		Mockito.when(
 			_indexReindexerRegistry.getIndexReindexers()
@@ -61,10 +71,57 @@ public class ReindexIndexReindexerBackgroundTaskExecutorTest {
 			"_reindexStatusMessageSender", _reindexStatusMessageSender);
 	}
 
-	@Test
-	public void testDatabasePartitioning() throws Exception {
-		Mockito.doAnswer(
-			invocation -> {
+        @Test
+        public void testBackgroundTaskCompanyIdsSerialization() throws Exception {
+                long[] companyIds = {0L, 42184964271267L};
+
+                Map<String, Object> taskContextMap = HashMapBuilder.<String, Object>put(
+                        ReindexBackgroundTaskConstants.CLASS_NAME, "className"
+                ).put(
+                        ReindexBackgroundTaskConstants.COMPANY_IDS, companyIds
+                ).put(
+                        ReindexBackgroundTaskConstants.EXECUTION_MODE, _EXECUTION_MODE
+                ).build();
+
+                @SuppressWarnings("unchecked")
+                Map<String, Object> deserializedTaskContextMap =
+                        (Map<String, Object>)JSONFactoryUtil.looseDeserialize(
+                                JSONFactoryUtil.looseSerialize(taskContextMap));
+
+                BackgroundTask backgroundTask = Mockito.mock(BackgroundTask.class);
+
+                Mockito.when(
+                        backgroundTask.getTaskContextMap()
+                ).thenReturn(
+                        (Map<String, Serializable>)(Map)deserializedTaskContextMap
+                );
+
+                AtomicInteger atomicInteger = new AtomicInteger();
+
+                Mockito.doAnswer(
+                        invocation -> {
+                                Assert.assertEquals(
+                                        companyIds[atomicInteger.getAndIncrement()],
+                                        invocation.getArgument(0));
+
+                                return null;
+                        }
+                ).when(
+                        _indexReindexer1
+                ).reindex(
+                        Mockito.anyLong(), Mockito.anyString()
+                );
+
+                _reindexIndexReindexerBackgroundTaskExecutor.execute(
+                        backgroundTask);
+
+                Assert.assertEquals(companyIds.length, atomicInteger.get());
+        }
+
+        @Test
+        public void testDatabasePartitioning() throws Exception {
+                Mockito.doAnswer(
+                        invocation -> {
 				Assert.assertEquals(
 					invocation.getArgument(0),
 					CompanyThreadLocal.getCompanyId());
@@ -73,59 +130,66 @@ public class ReindexIndexReindexerBackgroundTaskExecutorTest {
 			}
 		).when(
 			_indexReindexer1
-		).reindex(
-			Mockito.anyLong(), Mockito.anyString()
-		);
+                ).reindex(
+                        Mockito.anyLong(), Mockito.anyString()
+                );
 
-		_reindexIndexReindexerBackgroundTaskExecutor.reindex(
-			"", _COMPANY_IDS, _EXECUTION_MODE);
-	}
+                _reindexIndexReindexerBackgroundTaskExecutor.reindex(
+                        "", _COMPANY_IDS, _EXECUTION_MODE);
+        }
 
 	@Test
 	public void testReindexAllClasses() throws Exception {
-		_reindexIndexReindexerBackgroundTaskExecutor.reindex(
-			"", _COMPANY_IDS, _EXECUTION_MODE);
+                _reindexIndexReindexerBackgroundTaskExecutor.reindex(
+                        "", _COMPANY_IDS, _EXECUTION_MODE);
 
-		_verifyIndexerCalledOnceForEachCompany(_indexReindexer1);
-		_verifyIndexerCalledOnceForEachCompany(_indexReindexer2);
-	}
+                _verifyIndexerCalledOnceForEachCompany(_indexReindexer1);
+                _verifyIndexerCalledOnceForEachCompany(_indexReindexer2);
+        }
 
 	@Test
 	public void testReindexSingleClass() throws Exception {
-		_reindexIndexReindexerBackgroundTaskExecutor.reindex(
-			"className", _COMPANY_IDS, _EXECUTION_MODE);
+                _reindexIndexReindexerBackgroundTaskExecutor.reindex(
+                        "className", _COMPANY_IDS, _EXECUTION_MODE);
 
 		_verifyIndexerCalledOnceForEachCompany(_indexReindexer1);
 
 		Mockito.verify(
 			_indexReindexer2, Mockito.never()
-		).reindex(
-			_COMPANY_IDS[0], _EXECUTION_MODE
-		);
+                ).reindex(
+                        _COMPANY_IDS_ARRAY[0], _EXECUTION_MODE
+                );
 
 		Mockito.verify(
 			_indexReindexer2, Mockito.never()
-		).reindex(
-			_COMPANY_IDS[1], _EXECUTION_MODE
-		);
-	}
+                ).reindex(
+                        _COMPANY_IDS_ARRAY[1], _EXECUTION_MODE
+                );
+        }
 
 	private void _verifyIndexerCalledOnceForEachCompany(
 			IndexReindexer indexReindexer)
 		throws Exception {
 
-		for (long companyId : _COMPANY_IDS) {
-			Mockito.verify(
-				indexReindexer
-			).reindex(
-				companyId, _EXECUTION_MODE
+                for (long companyId : _COMPANY_IDS) {
+                        Mockito.verify(
+                                indexReindexer
+                        ).reindex(
+                                companyId, _EXECUTION_MODE
 			);
 		}
 	}
 
-	private static final long[] _COMPANY_IDS = {11111L, 22222L};
+        private static final long[] _COMPANY_IDS_ARRAY = {11111L, 22222L};
 
-	private static final String _EXECUTION_MODE = "full";
+        private static final List<Long> _COMPANY_IDS = Arrays.stream(
+                _COMPANY_IDS_ARRAY
+        ).boxed(
+        ).collect(
+                Collectors.toList()
+        );
+
+        private static final String _EXECUTION_MODE = "full";
 
 	private final IndexReindexer _indexReindexer1 = Mockito.mock(
 		IndexReindexer.class);

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexWriterHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexWriterHelperImpl.java
@@ -37,10 +37,13 @@ import com.liferay.portal.search.model.uid.UIDFactory;
 
 import java.io.Serializable;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -406,14 +409,15 @@ public class IndexWriterHelperImpl implements IndexWriterHelper {
 			Map<String, Serializable> taskContextMap)
 		throws SearchException {
 
-		if (taskContextMap == null) {
-			taskContextMap = new HashMap<>();
-		}
+                if (taskContextMap == null) {
+                        taskContextMap = new HashMap<>();
+                }
 
-		taskContextMap.put(
-			BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS, true);
-		taskContextMap.put(
-			ReindexBackgroundTaskConstants.COMPANY_IDS, companyIds);
+                taskContextMap.put(
+                        BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS, true);
+                taskContextMap.put(
+                        ReindexBackgroundTaskConstants.COMPANY_IDS,
+                        _toCompanyIds(companyIds));
 
 		try {
 			return _backgroundTaskManager.addBackgroundTask(
@@ -437,16 +441,17 @@ public class IndexWriterHelperImpl implements IndexWriterHelper {
 			return reindex(userId, jobName, companyIds, taskContextMap);
 		}
 
-		if (taskContextMap == null) {
-			taskContextMap = new HashMap<>();
-		}
+                if (taskContextMap == null) {
+                        taskContextMap = new HashMap<>();
+                }
 
-		taskContextMap.put(
-			BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS, true);
-		taskContextMap.put(
-			ReindexBackgroundTaskConstants.CLASS_NAME, className);
-		taskContextMap.put(
-			ReindexBackgroundTaskConstants.COMPANY_IDS, companyIds);
+                taskContextMap.put(
+                        BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS, true);
+                taskContextMap.put(
+                        ReindexBackgroundTaskConstants.CLASS_NAME, className);
+                taskContextMap.put(
+                        ReindexBackgroundTaskConstants.COMPANY_IDS,
+                        _toCompanyIds(companyIds));
 
 		try {
 			return _backgroundTaskManager.addBackgroundTask(
@@ -580,15 +585,24 @@ public class IndexWriterHelperImpl implements IndexWriterHelper {
 		uidFactory.getUID(document);
 	}
 
-	private String _getIndexerModelName(String name) {
-		String[] names = StringUtil.split(
-			name, ResourceActionsUtil.getCompositeModelNameSeparator());
+        private String _getIndexerModelName(String name) {
+                String[] names = StringUtil.split(
+                        name, ResourceActionsUtil.getCompositeModelNameSeparator());
 
-		return names[0];
-	}
+                return names[0];
+        }
 
-	private void _setCommitImmediately(
-		SearchContext searchContext, boolean commitImmediately) {
+        private List<Long> _toCompanyIds(long[] companyIds) {
+                return Arrays.stream(
+                        companyIds
+                ).boxed(
+                ).collect(
+                        Collectors.toList()
+                );
+        }
+
+        private void _setCommitImmediately(
+                SearchContext searchContext, boolean commitImmediately) {
 
 		if (!commitImmediately) {
 			searchContext.setCommitImmediately(_commitImmediately);

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/BaseReindexBackgroundTaskExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/BaseReindexBackgroundTaskExecutor.java
@@ -15,7 +15,10 @@ import com.liferay.portal.search.internal.background.task.display.ReindexBackgro
 
 import java.io.Serializable;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * @author Andrew Betts
@@ -32,17 +35,16 @@ public abstract class BaseReindexBackgroundTaskExecutor
 	public BackgroundTaskResult execute(BackgroundTask backgroundTask)
 		throws Exception {
 
-		Map<String, Serializable> taskContextMap =
-			backgroundTask.getTaskContextMap();
+                Map<String, Serializable> taskContextMap =
+                        backgroundTask.getTaskContextMap();
 
-		String className = (String)taskContextMap.get(
-			ReindexBackgroundTaskConstants.CLASS_NAME);
-		long[] companyIds = GetterUtil.getLongValues(
-			taskContextMap.get(ReindexBackgroundTaskConstants.COMPANY_IDS));
-		String executionMode = (String)taskContextMap.get(
-			ReindexBackgroundTaskConstants.EXECUTION_MODE);
+                String className = (String)taskContextMap.get(
+                        ReindexBackgroundTaskConstants.CLASS_NAME);
+                List<Long> companyIds = _getCompanyIds(taskContextMap);
+                String executionMode = (String)taskContextMap.get(
+                        ReindexBackgroundTaskConstants.EXECUTION_MODE);
 
-		reindex(className, companyIds, executionMode);
+                reindex(className, companyIds, executionMode);
 
 		return BackgroundTaskResult.SUCCESS;
 	}
@@ -52,10 +54,34 @@ public abstract class BaseReindexBackgroundTaskExecutor
 		BackgroundTask backgroundTask) {
 
 		return new ReindexBackgroundTaskDisplay(backgroundTask);
-	}
+        }
 
-	protected abstract void reindex(
-			String className, long[] companyIds, String executionMode)
-		throws Exception;
+        protected abstract void reindex(
+                        String className, List<Long> companyIds, String executionMode)
+                throws Exception;
+
+        private List<Long> _getCompanyIds(
+                Map<String, Serializable> taskContextMap) {
+
+                Object companyIds = taskContextMap.get(
+                        ReindexBackgroundTaskConstants.COMPANY_IDS);
+
+                if (companyIds instanceof List) {
+                        List<?> companyIdsList = (List<?>)companyIds;
+
+                        return companyIdsList.stream(
+                        ).map(
+                                GetterUtil::getLong
+                        ).collect(
+                                Collectors.toList()
+                        );
+                }
+
+                return Arrays.stream(
+                        GetterUtil.getLongValues(companyIds)
+                ).boxed().collect(
+                        Collectors.toList()
+                );
+        }
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexIndexReindexerBackgroundTaskExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexIndexReindexerBackgroundTaskExecutor.java
@@ -13,11 +13,13 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.background.task.ReindexBackgroundTaskConstants;
 import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSender;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.spi.reindexer.IndexReindexer;
 import com.liferay.portal.search.spi.reindexer.IndexReindexerRegistry;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -35,39 +37,41 @@ public class ReindexIndexReindexerBackgroundTaskExecutor
 	@Override
 	public BackgroundTaskExecutor clone() {
 		return this;
-	}
+        }
 
-	@Override
-	protected void reindex(
-			String className, long[] companyIds, String executionMode)
-		throws Exception {
+        @Override
+        protected void reindex(
+                        String className, List<Long> companyIds, String executionMode)
+                throws Exception {
 
-		if (Validator.isBlank(className)) {
-			Collection<IndexReindexer> indexReindexers =
-				_indexReindexerRegistry.getIndexReindexers();
+                long[] companyIdsArray = ArrayUtil.toLongArray(companyIds);
 
-			for (IndexReindexer indexReindexer : indexReindexers) {
-				Class<?> clazz = indexReindexer.getClass();
+                if (Validator.isBlank(className)) {
+                        Collection<IndexReindexer> indexReindexers =
+                                _indexReindexerRegistry.getIndexReindexers();
 
-				_reindex(
-					clazz.getName(), companyIds, executionMode, indexReindexer,
-					null, null);
-			}
-		}
-		else {
-			IndexReindexer indexReindexer =
-				_indexReindexerRegistry.getIndexReindexer(className);
+                        for (IndexReindexer indexReindexer : indexReindexers) {
+                                Class<?> clazz = indexReindexer.getClass();
+
+                                _reindex(
+                                        clazz.getName(), companyIdsArray, executionMode,
+                                        indexReindexer, null, null);
+                        }
+                }
+                else {
+                        IndexReindexer indexReindexer =
+                                _indexReindexerRegistry.getIndexReindexer(className);
 
 			if (indexReindexer == null) {
 				return;
-			}
+                        }
 
-			_reindex(
-				className, companyIds, executionMode, indexReindexer,
-				ReindexBackgroundTaskConstants.SINGLE_START,
-				ReindexBackgroundTaskConstants.SINGLE_END);
-		}
-	}
+                        _reindex(
+                                className, companyIdsArray, executionMode, indexReindexer,
+                                ReindexBackgroundTaskConstants.SINGLE_START,
+                                ReindexBackgroundTaskConstants.SINGLE_END);
+                }
+        }
 
 	private void _reindex(
 			String className, long[] companyIds, String executionMode,

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexPortalBackgroundTaskExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexPortalBackgroundTaskExecutor.java
@@ -13,9 +13,12 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.search.background.task.ReindexBackgroundTaskConstants;
 import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSenderUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.search.index.ConcurrentReindexManager;
 import com.liferay.portal.search.index.SyncReindexManager;
 import com.liferay.portal.search.internal.SearchEngineInitializer;
+
+import java.util.List;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -43,14 +46,16 @@ public class ReindexPortalBackgroundTaskExecutor
 	}
 
 	@Override
-	protected void reindex(
-			String className, long[] companyIds, String executionMode)
-		throws Exception {
+        protected void reindex(
+                        String className, List<Long> companyIds, String executionMode)
+                throws Exception {
 
-		for (long companyId : companyIds) {
-			ReindexStatusMessageSenderUtil.sendStatusMessage(
-				ReindexBackgroundTaskConstants.PORTAL_START, companyId,
-				companyIds);
+                long[] companyIdsArray = ArrayUtil.toLongArray(companyIds);
+
+                for (long companyId : companyIdsArray) {
+                        ReindexStatusMessageSenderUtil.sendStatusMessage(
+                                ReindexBackgroundTaskConstants.PORTAL_START, companyId,
+                                companyIdsArray);
 
 			if (_log.isInfoEnabled()) {
 				_log.info(
@@ -70,12 +75,12 @@ public class ReindexPortalBackgroundTaskExecutor
 				searchEngineInitializer.reindex();
 			}
 			catch (Exception exception) {
-				_log.error(exception);
-			}
-			finally {
-				ReindexStatusMessageSenderUtil.sendStatusMessage(
-					ReindexBackgroundTaskConstants.PORTAL_END, companyId,
-					companyIds);
+                                _log.error(exception);
+                        }
+                        finally {
+                                ReindexStatusMessageSenderUtil.sendStatusMessage(
+                                        ReindexBackgroundTaskConstants.PORTAL_END, companyId,
+                                        companyIdsArray);
 
 				if (_log.isInfoEnabled()) {
 					_log.info(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutor.java
@@ -26,6 +26,7 @@ import com.liferay.portal.search.index.SyncReindexManager;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -60,12 +61,12 @@ public class ReindexSingleIndexerBackgroundTaskExecutor
 		if (systemIndexers != null) {
 			systemIndexers.close();
 		}
-	}
+        }
 
-	@Override
-	protected void reindex(
-			String className, long[] companyIds, String executionMode)
-		throws Exception {
+        @Override
+        protected void reindex(
+                        String className, List<Long> companyIds, String executionMode)
+                throws Exception {
 
 		Indexer<?> indexer = indexerRegistry.getIndexer(className);
 
@@ -77,9 +78,9 @@ public class ReindexSingleIndexerBackgroundTaskExecutor
 
 		boolean systemIndexer = _isSystemIndexer(indexer);
 
-		for (long companyId : companyIds) {
-			if (((companyId == CompanyConstants.SYSTEM) && !systemIndexer) ||
-				((companyId != CompanyConstants.SYSTEM) && systemIndexer)) {
+                for (long companyId : companyIds) {
+                        if (((companyId == CompanyConstants.SYSTEM) && !systemIndexer) ||
+                                ((companyId != CompanyConstants.SYSTEM) && systemIndexer)) {
 
 				continue;
 			}


### PR DESCRIPTION
## Summary
- use `List<Long>` company ids within reindex background task executors to avoid overflow from JSON deserialization
- send company ids as lists when scheduling search reindex background tasks
- add a regression test that exercises background task serialization with large company ids

## Testing
- `./gradlew formatSource` *(fails: gradle distribution zip unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447ca58604832f80a67a2878513c90)