### PR TITLE
LPD-53548 Search Bar can be configured inside a Content page when the Header search bar can overwrite it

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelper.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelper.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.search.web.internal.search.bar.portlet.helper;
 
+import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.portal.kernel.model.Layout;
@@ -35,9 +36,14 @@ import org.osgi.service.component.annotations.Reference;
 public class SearchBarPrecedenceHelper {
 
 	public Portlet findHeaderSearchBarPortlet(ThemeDisplay themeDisplay) {
-		List<Portlet> portlets = _getPortlets(themeDisplay);
+		Portlet headerSearchBarPortlet =
+			_findMasterLayoutHeaderSearchBarPortlet(themeDisplay);
 
-		Portlet headerSearchBarPortlet = null;
+		if (headerSearchBarPortlet != null) {
+			return headerSearchBarPortlet;
+		}
+
+		List<Portlet> portlets = _getPortlets(themeDisplay);
 
 		for (Portlet portlet : portlets) {
 			if (_isHeaderSearchBar(portlet)) {
@@ -111,6 +117,48 @@ public class SearchBarPrecedenceHelper {
 		return Objects.equals(
 			searchBarPortletPreferences1.getFederatedSearchKey(),
 			searchBarPortletPreferences2.getFederatedSearchKey());
+	}
+
+	private Portlet _findMasterLayoutHeaderSearchBarPortlet(
+		ThemeDisplay themeDisplay) {
+
+		Layout layout = themeDisplay.getLayout();
+
+		if ((!layout.isTypeAssetDisplay() && !layout.isTypeContent()) ||
+			(layout.getMasterLayoutPlid() <= 0)) {
+
+			return null;
+		}
+
+		Layout masterLayout = _layoutLocalService.fetchLayout(
+			layout.getMasterLayoutPlid());
+
+		if (masterLayout == null) {
+			return null;
+		}
+
+		for (FragmentEntryLink fragmentEntryLink :
+				_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+					masterLayout.getGroupId(), masterLayout.getPlid())) {
+
+			for (String portletId :
+					_portletRegistry.getFragmentEntryLinkPortletIds(
+						fragmentEntryLink)) {
+
+				Portlet portlet = _portletLocalService.getPortletById(
+					themeDisplay.getCompanyId(), portletId);
+
+				if ((portlet != null) &&
+					Objects.equals(
+						portlet.getPortletName(),
+						SearchBarPortletKeys.SEARCH_BAR)) {
+
+					return portlet;
+				}
+			}
+		}
+
+		return null;
 	}
 
 	private List<Portlet> _getPortlets(ThemeDisplay themeDisplay) {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelper.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelper.java
@@ -5,11 +5,14 @@
 
 package com.liferay.portal.search.web.internal.search.bar.portlet.helper;
 
+import com.liferay.fragment.processor.PortletRegistry;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -155,9 +158,18 @@ public class SearchBarPrecedenceHelper {
 	}
 
 	@Reference
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
 	private PortletLocalService _portletLocalService;
 
 	@Reference
 	private PortletPreferencesLookup _portletPreferencesLookup;
+
+	@Reference
+	private PortletRegistry _portletRegistry;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelper.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelper.java
@@ -8,6 +8,7 @@ package com.liferay.portal.search.web.internal.search.bar.portlet.helper;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
@@ -210,6 +211,9 @@ public class SearchBarPrecedenceHelper {
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutPageTemplateEntryService _layoutPageTemplateEntryService;
 
 	@Reference
 	private PortletLocalService _portletLocalService;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelper.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelper.java
@@ -8,6 +8,8 @@ package com.liferay.portal.search.web.internal.search.bar.portlet.helper;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
@@ -18,6 +20,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.web.constants.SearchBarPortletKeys;
 import com.liferay.portal.search.web.internal.portlet.preferences.PortletPreferencesLookup;
 import com.liferay.portal.search.web.internal.search.bar.portlet.SearchBarPortletDestinationUtil;
@@ -125,14 +128,11 @@ public class SearchBarPrecedenceHelper {
 
 		Layout layout = themeDisplay.getLayout();
 
-		if ((!layout.isTypeAssetDisplay() && !layout.isTypeContent()) ||
-			(layout.getMasterLayoutPlid() <= 0)) {
-
+		if (!layout.isTypeAssetDisplay() && !layout.isTypeContent()) {
 			return null;
 		}
 
-		Layout masterLayout = _layoutLocalService.fetchLayout(
-			layout.getMasterLayoutPlid());
+		Layout masterLayout = _getMasterLayout(layout);
 
 		if (masterLayout == null) {
 			return null;
@@ -160,6 +160,26 @@ public class SearchBarPrecedenceHelper {
 		}
 
 		return null;
+	}
+
+	private Layout _getMasterLayout(Layout layout) {
+		if (layout.getMasterLayoutPlid() > 0) {
+			return _layoutLocalService.fetchLayout(
+				layout.getMasterLayoutPlid());
+		}
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryService.fetchDefaultLayoutPageTemplateEntry(
+				layout.getGroupId(),
+				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT,
+				WorkflowConstants.STATUS_APPROVED);
+
+		if (layoutPageTemplateEntry == null) {
+			return null;
+		}
+
+		return _layoutLocalService.fetchLayout(
+			layoutPageTemplateEntry.getPlid());
 	}
 
 	private List<Portlet> _getPortlets(ThemeDisplay themeDisplay) {

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelperTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelperTest.java
@@ -8,6 +8,9 @@ package com.liferay.portal.search.web.internal.search.bar.portlet.helper;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -21,6 +24,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.web.constants.SearchBarPortletKeys;
 import com.liferay.portal.search.web.internal.portlet.preferences.PortletPreferencesLookup;
 import com.liferay.portal.search.web.internal.search.bar.portlet.SearchBarPortletPreferences;
@@ -59,6 +63,20 @@ public class SearchBarPrecedenceHelperTest {
 
 		_searchBarPrecedenceHelper = _createSearchBarPrecedenceHelper();
 		_themeDisplay = _createThemeDisplay(layout);
+	}
+
+	@Test
+	public void testContentPageWithDefaultMasterLayoutHeaderSearchBar() {
+		_setThemeDisplayLayoutFriendlyURL(_DESTINATION);
+
+		String federatedSearchKey = RandomTestUtil.randomString();
+
+		_addSearchBarPortletToDefaultMasterLayout(federatedSearchKey);
+
+		Portlet portlet = _addSearchBarPortletToPage(federatedSearchKey);
+
+		Assert.assertTrue(
+			isSearchBarInBodyWithHeaderSearchBarAlreadyPresent(portlet));
 	}
 
 	@Test
@@ -205,6 +223,86 @@ public class SearchBarPrecedenceHelperTest {
 		);
 
 		return portlet;
+	}
+
+	private void _addSearchBarPortletToDefaultMasterLayout(
+		String federatedSearchKey) {
+
+		Mockito.when(
+			_layout.isTypeContent()
+		).thenReturn(
+			true
+		);
+
+		long masterLayoutPlid = RandomTestUtil.randomLong();
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry = Mockito.mock(
+			LayoutPageTemplateEntry.class);
+
+		Mockito.when(
+			layoutPageTemplateEntry.getPlid()
+		).thenReturn(
+			masterLayoutPlid
+		);
+
+		Mockito.when(
+			_layoutPageTemplateEntryService.fetchDefaultLayoutPageTemplateEntry(
+				0L, LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT,
+				WorkflowConstants.STATUS_APPROVED)
+		).thenReturn(
+			layoutPageTemplateEntry
+		);
+
+		Layout masterLayout = Mockito.mock(Layout.class);
+
+		Mockito.when(
+			masterLayout.getPlid()
+		).thenReturn(
+			masterLayoutPlid
+		);
+
+		Mockito.when(
+			_layoutLocalService.fetchLayout(masterLayoutPlid)
+		).thenReturn(
+			masterLayout
+		);
+
+		String defaultMasterHeaderSearchBarPortletId =
+			"defaultMasterHeaderSearchBarPortletId";
+
+		Portlet portlet = _createPortlet(
+			false, defaultMasterHeaderSearchBarPortletId);
+
+		Mockito.when(
+			_portletLocalService.getPortletById(
+				0, defaultMasterHeaderSearchBarPortletId)
+		).thenReturn(
+			portlet
+		);
+
+		Mockito.doReturn(
+			_createPortletPreferences(federatedSearchKey, _DESTINATION)
+		).when(
+			_portletPreferencesLookup
+		).fetchPreferences(
+			portlet, _themeDisplay
+		);
+
+		FragmentEntryLink fragmentEntryLink = Mockito.mock(
+			FragmentEntryLink.class);
+
+		Mockito.when(
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				0L, masterLayoutPlid)
+		).thenReturn(
+			Collections.singletonList(fragmentEntryLink)
+		);
+
+		Mockito.when(
+			_portletRegistry.getFragmentEntryLinkPortletIds(fragmentEntryLink)
+		).thenReturn(
+			Collections.singletonList(defaultMasterHeaderSearchBarPortletId)
+		);
 	}
 
 	private void _addSearchBarPortletToHeader(String federatedSearchKey) {
@@ -402,6 +500,9 @@ public class SearchBarPrecedenceHelperTest {
 			searchBarPrecedenceHelper, "_layoutLocalService",
 			_layoutLocalService);
 		ReflectionTestUtil.setFieldValue(
+			searchBarPrecedenceHelper, "_layoutPageTemplateEntryService",
+			_layoutPageTemplateEntryService);
+		ReflectionTestUtil.setFieldValue(
 			searchBarPrecedenceHelper, "_portletLocalService",
 			_portletLocalService);
 		ReflectionTestUtil.setFieldValue(
@@ -452,6 +553,9 @@ public class SearchBarPrecedenceHelperTest {
 	private Layout _layout;
 	private final LayoutLocalService _layoutLocalService = Mockito.mock(
 		LayoutLocalService.class);
+	private final LayoutPageTemplateEntryService
+		_layoutPageTemplateEntryService = Mockito.mock(
+			LayoutPageTemplateEntryService.class);
 	private final PortletLocalService _portletLocalService = Mockito.mock(
 		PortletLocalService.class);
 	private final PortletPreferencesLookup _portletPreferencesLookup =

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelperTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/helper/SearchBarPrecedenceHelperTest.java
@@ -5,6 +5,9 @@
 
 package com.liferay.portal.search.web.internal.search.bar.portlet.helper;
 
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.processor.PortletRegistry;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -12,6 +15,7 @@ import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -25,6 +29,7 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import jakarta.portlet.PortletPreferences;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -54,6 +59,20 @@ public class SearchBarPrecedenceHelperTest {
 
 		_searchBarPrecedenceHelper = _createSearchBarPrecedenceHelper();
 		_themeDisplay = _createThemeDisplay(layout);
+	}
+
+	@Test
+	public void testContentPageWithMasterLayoutHeaderSearchBar() {
+		_setThemeDisplayLayoutFriendlyURL(_DESTINATION);
+
+		String federatedSearchKey = RandomTestUtil.randomString();
+
+		_addSearchBarPortletToMasterLayout(federatedSearchKey);
+
+		Portlet portlet = _addSearchBarPortletToPage(federatedSearchKey);
+
+		Assert.assertTrue(
+			isSearchBarInBodyWithHeaderSearchBarAlreadyPresent(portlet));
 	}
 
 	@Test
@@ -193,6 +212,72 @@ public class SearchBarPrecedenceHelperTest {
 			_DESTINATION, federatedSearchKey, true, "headerSearchBarPortletId");
 	}
 
+	private void _addSearchBarPortletToMasterLayout(String federatedSearchKey) {
+		long masterLayoutPlid = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_layout.getMasterLayoutPlid()
+		).thenReturn(
+			masterLayoutPlid
+		);
+
+		Mockito.when(
+			_layout.isTypeContent()
+		).thenReturn(
+			true
+		);
+
+		Layout masterLayout = Mockito.mock(Layout.class);
+
+		Mockito.when(
+			masterLayout.getPlid()
+		).thenReturn(
+			masterLayoutPlid
+		);
+
+		Mockito.when(
+			_layoutLocalService.fetchLayout(masterLayoutPlid)
+		).thenReturn(
+			masterLayout
+		);
+
+		String masterHeaderSearchBarPortletId =
+			"masterHeaderSearchBarPortletId";
+
+		Portlet portlet = _createPortlet(false, masterHeaderSearchBarPortletId);
+
+		Mockito.when(
+			_portletLocalService.getPortletById(
+				0, masterHeaderSearchBarPortletId)
+		).thenReturn(
+			portlet
+		);
+
+		Mockito.doReturn(
+			_createPortletPreferences(federatedSearchKey, _DESTINATION)
+		).when(
+			_portletPreferencesLookup
+		).fetchPreferences(
+			portlet, _themeDisplay
+		);
+
+		FragmentEntryLink fragmentEntryLink = Mockito.mock(
+			FragmentEntryLink.class);
+
+		Mockito.when(
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				0L, masterLayoutPlid)
+		).thenReturn(
+			Collections.singletonList(fragmentEntryLink)
+		);
+
+		Mockito.when(
+			_portletRegistry.getFragmentEntryLinkPortletIds(fragmentEntryLink)
+		).thenReturn(
+			Collections.singletonList(masterHeaderSearchBarPortletId)
+		);
+	}
+
 	private Portlet _addSearchBarPortletToPage(String federatedSearchKey) {
 		return _addPortlet(
 			_DESTINATION, federatedSearchKey, false, "searchBarPortletId");
@@ -311,11 +396,19 @@ public class SearchBarPrecedenceHelperTest {
 			new SearchBarPrecedenceHelper();
 
 		ReflectionTestUtil.setFieldValue(
+			searchBarPrecedenceHelper, "_fragmentEntryLinkLocalService",
+			_fragmentEntryLinkLocalService);
+		ReflectionTestUtil.setFieldValue(
+			searchBarPrecedenceHelper, "_layoutLocalService",
+			_layoutLocalService);
+		ReflectionTestUtil.setFieldValue(
 			searchBarPrecedenceHelper, "_portletLocalService",
 			_portletLocalService);
 		ReflectionTestUtil.setFieldValue(
 			searchBarPrecedenceHelper, "_portletPreferencesLookup",
 			_portletPreferencesLookup);
+		ReflectionTestUtil.setFieldValue(
+			searchBarPrecedenceHelper, "_portletRegistry", _portletRegistry);
 
 		return searchBarPrecedenceHelper;
 	}
@@ -354,11 +447,17 @@ public class SearchBarPrecedenceHelperTest {
 
 	private static final String _DESTINATION = RandomTestUtil.randomString();
 
+	private final FragmentEntryLinkLocalService _fragmentEntryLinkLocalService =
+		Mockito.mock(FragmentEntryLinkLocalService.class);
 	private Layout _layout;
+	private final LayoutLocalService _layoutLocalService = Mockito.mock(
+		LayoutLocalService.class);
 	private final PortletLocalService _portletLocalService = Mockito.mock(
 		PortletLocalService.class);
 	private final PortletPreferencesLookup _portletPreferencesLookup =
 		Mockito.mock(PortletPreferencesLookup.class);
+	private final PortletRegistry _portletRegistry = Mockito.mock(
+		PortletRegistry.class);
 	private final List<Portlet> _portlets = new ArrayList<>();
 	private SearchBarPrecedenceHelper _searchBarPrecedenceHelper;
 	private ThemeDisplay _themeDisplay;


### PR DESCRIPTION
## Summary

- On a Content Page (or Asset Display layout) whose master template contains a Search Bar fragment, the body Search Bar's configuration UI no longer leaves the Scope/Keywords/Scope-parameter fields enabled. The "For disabled fields, the page header Search Bar configuration takes precedence." warning now fires, mirroring widget-page behavior.
- `SearchBarPrecedenceHelper.findHeaderSearchBarPortlet` previously only scanned the current layout's static portlets via `LayoutTypePortlet.getAllPortlets(false)` — that path never sees fragment-instantiated portlets in the master layout. The helper now first walks the master layout's fragment entry links (mirroring the pattern already used by `PortletSharedSearchRequestImpl._getPortlets`) and returns any Search Bar found there.
- Added a unit test `testContentPageWithMasterLayoutHeaderSearchBar` that reproduces the bug.

https://liferay.atlassian.net/browse/LPD-53548

## Test plan

- [x] `cd modules && ../gradlew :apps:portal-search:portal-search-web:test --tests com.liferay.portal.search.web.internal.search.bar.portlet.helper.SearchBarPrecedenceHelperTest` (8 tests, all pass)
- [ ] Manual: create a master with a Search Bar fragment in its header, create a content page that uses that master, place a Search Bar fragment on the content page body, configure the body Search Bar — expect Scope/Keywords/Scope-parameter to be disabled and the precedence warning to appear.
- [ ] Manual regression: editing the Search Bar on the master itself should still allow Scope to be configured (LPD-55450 behavior is preserved).
- [ ] Manual regression: widget-page Search Bar configuration with header Search Bar still disables Scope on the body Search Bar.